### PR TITLE
fix(logger): don't print colors on windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/editorconfig-checker/editorconfig-checker
 
 go 1.12
 
-require github.com/editorconfig/editorconfig-core-go/v2 v2.0.0
+require (
+	github.com/editorconfig/editorconfig-core-go/v2 v2.0.0
+	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
+)

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=

--- a/pkg/logger/logger_windows.go
+++ b/pkg/logger/logger_windows.go
@@ -1,0 +1,34 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+)
+
+// Colors which can be used
+const (
+	YELLOW = "\x1b[33;1m"
+	GREEN  = "\x1b[32;1m"
+	RED    = "\x1b[31;1m"
+	RESET  = "\x1b[33;0m"
+)
+
+// Warning prints a warning message to Stdout in yellow
+func Warning(message string) {
+	Print(message, YELLOW, os.Stdout)
+}
+
+// Error prints an error message to Stderr in red
+func Error(message string) {
+	Print(message, RED, os.Stderr)
+}
+
+// Output prints a message on Stdout in 'normal' color
+func Output(message string) {
+	Print(message, RESET, os.Stdout)
+}
+
+// Print prints a message to a given stream in a defined color
+func Print(message string, color string, stream *os.File) {
+	fmt.Fprintf(stream, "%s\n", message)
+}


### PR DESCRIPTION
We should aim to use the ANSI-colors after Windows 10 builds higher than 10586 and do a workaround for versions lower than that.

closes #74