### PR TITLE
Better makefile for distros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Change `Dockerfile` `CMD` to allow the usage of `ec` everywhere inside the image [#105](https://github.com/editorconfig-checker/editorconfig-checker/pull/105) ([@chambo-e](https://github.com/chambo-e))
 ### Security
 ### Misc
+* Marked non-build targets in the Makefile as phony
 
 ## [2.0.3] - 2019-09-13
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### BREAKING
 ### Added
+* all, install and uninstall targets in the Makefile
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### BREAKING
 ### Added
 * all, install and uninstall targets in the Makefile
+* man page
 ### Deprecated
 ### Removed
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ COMPILE_COMMAND = go build -ldflags "-X main.version=$(CURRENT_VERSION)" -o bin/
 
 prefix = /usr/local
 bindir = /bin
+mandir = /share/man
 
 all: build
 
@@ -21,9 +22,11 @@ build: bin/ec
 
 install: build
 	install -D bin/ec $(DESTDIR)$(prefix)$(bindir)/editorconfig-checker
+	install -D docs/editorconfig-checker.1 $(DESTDIR)$(prefix)$(mandir)/man1/editorconfig-checker.1
 
 uninstall:
 	rm -f $(DESTDIR)$(prefix)$(bindir)/editorconfig-checker
+	rm -f $(DESTDIR)$(prefix)$(mandir)/man1/editorconfig-checker.1
 
 test:
 	@go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/Makefile
+++ b/Makefile
@@ -123,3 +123,5 @@ nix-install:
 
 nix-update-dependencies:
 	nix-shell -p vgo2nix --run vgo2nix
+
+.PHONY: clean build install uninstall test bench run run-verbose release _is_master_branch _git_branch_is_up_to_date current_version _do_release _tag_version _build-all-binaries _compress-all-binaries _release_dockerfile _build_dockerfile _push_dockerfile nix-build nix-install nix-update-dependencies

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ GIT_BRANCH_UP_TO_DATE = $(shell git remote show origin | tail -n1 | sed 's/.*(\(
 CURRENT_VERSION = $(shell cat VERSION | tr -d '\n')
 COMPILE_COMMAND = go build -ldflags "-X main.version=$(CURRENT_VERSION)" -o bin/ec ./cmd/editorconfig-checker/main.go
 
+prefix = /usr/local
+bindir = /bin
+
+all: build
+
 clean:
 	rm -f ./bin/*
 
@@ -13,6 +18,12 @@ bin/ec: $(SOURCES) VERSION
 	$(COMPILE_COMMAND)
 
 build: bin/ec
+
+install: build
+	install -D bin/ec $(DESTDIR)$(prefix)$(bindir)/editorconfig-checker
+
+uninstall:
+	rm -f $(DESTDIR)$(prefix)$(bindir)/editorconfig-checker
 
 test:
 	@go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/docs/editorconfig-checker.1
+++ b/docs/editorconfig-checker.1
@@ -1,0 +1,62 @@
+.\" Generated with help2man.
+.TH EDITORCONFIG-CHECKER "1" "User Commands"
+.SH NAME
+editorconfig-checker \- tool to verify that your files are in harmony with your .editorconfig
+.SH DESCRIPTION
+.SS "USAGE:"
+.HP
+\fB\-config\fR string
+.IP
+config
+.HP
+\fB\-debug\fR, \fB\-v\fR, \fB\-verbose\fR
+.IP
+print debugging information
+.HP
+\fB\-disable\-end\-of\-line\fR
+.IP
+disables the trailing whitespace check
+.HP
+\fB\-disable\-indent\-size\fR
+.IP
+disables only the indent\-size check
+.HP
+\fB\-disable\-indentation\fR
+.IP
+disables the indentation check
+.HP
+\fB\-disable\-insert\-final\-newline\fR
+.IP
+disables the final newline check
+.HP
+\fB\-disable\-trim\-trailing\-whitespace\fR
+.IP
+disables the trailing whitespace check
+.HP
+\fB\-dry\-run\fR
+.IP
+show which files would be checked
+.HP
+\fB\-exclude\fR string
+.IP
+a regex which files should be excluded from checking \- needs to be a valid regular expression
+.HP
+\fB\-h\fR, \fB\-\-help\fR
+.IP
+print the help
+.HP
+\fB\-ignore\-defaults\fR
+.IP
+ignore default excludes
+.HP
+\fB\-init\fR
+.IP
+creates an initial configuration
+.HP
+\fB\-no\-color\fR
+.IP
+dont print colors
+.HP
+\fB\-version\fR
+.IP
+print the version number


### PR DESCRIPTION
I'm currently interested to pack editorconfig-checker for Debian, however there is no installation process in place. So I did this in the first commit by adding three targets: all (default build target), install and uninstall. I also used standard path names, using the default values even though they will be overwritten by most distros (e. g. `/usr` as prefix instead of `/usr/local`).
In the second commit I marked basically all targets except `bin/ec` as phony. Normally, make expects that the name of a target is the output file, but that's not the case here.
In the third commit I added a basic man page, mostly auto generated with a bit of optical lifting. You can view it with `man -l docs/editorconfig-checker.1`, note here that the `-config` option has a pretty bad description (taken from `bin/ec --help`), you may want to change it.