### PR TITLE
chore: fix spelling error

### DIFF
--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -144,7 +144,7 @@ func LineEnding(fileContent string, endOfLine string) error {
 func MaxLineLength(line string, maxLineLength int) error {
 	length := len(line)
 	if length > maxLineLength {
-		return fmt.Errorf("Line to long (%d instead of %d)", length, maxLineLength)
+		return fmt.Errorf("Line too long (%d instead of %d)", length, maxLineLength)
 	}
 
 	return nil

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -247,8 +247,8 @@ func TestMaxLineLength(t *testing.T) {
 		expected      error
 	}{
 		{"", 80, nil},
-		{"abc", 2, errors.New("Line to long (3 instead of 2)")},
-		{"   ", 2, errors.New("Line to long (3 instead of 2)")},
+		{"abc", 2, errors.New("Line too long (3 instead of 2)")},
+		{"   ", 2, errors.New("Line too long (3 instead of 2)")},
 		{"xx", 2, nil},
 	}
 


### PR DESCRIPTION
'to' → 'too'