### PR TITLE
Add support for disabling blocks, implements #124

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### BREAKING
 ### Added
+* Add support for disabling validation via `editorconfig-checker-disable` and re-enabling with `editorconfig-checker-enable` [#126](https://github.com/editorconfig-checker/editorconfig-checker/pull/126)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -163,6 +163,19 @@ const myTemplateString = `
      wrongly indended line because it needs to be` // editorconfig-checker-disable-line
 ```
 
+### Excluding blocks
+
+To temporarily disable all checks, add a comment containing `editorconfig-checker-disable`. Re-enable with a comment containing `editorconfig-checker-enable`
+
+```js
+// editorconfig-checker-disable
+const myTemplateString = `
+  first line 
+     wrongly indended line because it needs to be
+`
+// editorconfig-checker-enable
+```
+
 ### Excluding files
 
 #### Inline

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -66,6 +66,16 @@ func TestValidateFile(t *testing.T) {
 		t.Error("Should have no errors when validating valid file, got", result)
 	}
 
+	result = ValidateFile("./../../testfiles/disabled-block.txt", configuration)
+	if len(result) != 0 {
+		t.Error("Should have no errors when validating valid file, got", result)
+	}
+
+	result = ValidateFile("./../../testfiles/disabled-block-with-error.txt", configuration)
+	if len(result) != 1 {
+		t.Error("Should have one error, got", result)
+	}
+
 	configuration = config.Config{SpacesAftertabs: false}
 	result = ValidateFile("./../../testfiles/spaces-after-tabs.txt", configuration)
 	if len(result) != 1 {

--- a/testfiles/disabled-block-with-error.txt
+++ b/testfiles/disabled-block-with-error.txt
@@ -1,0 +1,6 @@
+hello
+<!-- editorconfig-checker-disable -->
+	 world
+		 world2
+<!-- editorconfig-checker-enable -->
+	 wrong indentation

--- a/testfiles/disabled-block.txt
+++ b/testfiles/disabled-block.txt
@@ -1,0 +1,6 @@
+hello
+<!-- editorconfig-checker-disable -->
+	 world
+		 world2
+<!-- editorconfig-checker-enable -->
+test


### PR DESCRIPTION
As requested in #124, this augments the existing `editorconfig-checker-disable-line` functionality to allow disabling checks for a block of code by adding a comment with `editorconfig-checker-disable`. Checks can be re-enabled with a comment containing `editorconfig-checker-enable`. This is very similar to how ESLint facilitates excludes: https://eslint.org/docs/user-guide/configuring#disabling-rules-with-inline-comments

Note that this functionality basically renders `editorconfig-checker-disable-file` redundant, because you can accomplish the same thing by adding `editorconfig-checker-disable` to the top of the file. I wasn't sure if `editorconfig-checker-disable-file` should be preserved or not, so I didn't touch it. 

closes #124 