### PR TITLE
Make GetRelativePath() more robust, fixes #121

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+* Fix file path corruption [#121](https://github.com/editorconfig-checker/editorconfig-checker/issues/121)
 ### Security
 ### Misc
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -184,13 +184,17 @@ func PathExists(filePath string) bool {
 
 // GetRelativePath returns the relative path of a file from the current working directory
 func GetRelativePath(filePath string) (string, error) {
+	if !filepath.IsAbs(filePath) {
+		// Path is already relative. No changes needed
+		return filePath, nil
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("Could not get the current working directory")
 	}
 
-	relativePath := strings.Replace(filePath, cwd, ".", 1)
-	return relativePath, nil
+	return filepath.Rel(cwd, filePath)
 }
 
 // IsAllowedContentType returns wether the contentType is

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -78,12 +78,19 @@ func TestPathExists(t *testing.T) {
 }
 
 func TestGetRelativePath(t *testing.T) {
+	// Should return paths that are already relative unchanged
+	relativeFilePath, _ := GetRelativePath("bin/ec")
+	if relativeFilePath != "bin/ec" {
+		t.Errorf("GetRelativePath(%s): expected: %v, got: %v", "bin/ec", "bin/ec", relativeFilePath)
+	}
+
+	// Should convert absolute paths to be relative to current directory
 	cwd, _ := os.Getwd()
 	filePath := "/bin/ec"
-	relativeFilePath, _ := GetRelativePath(cwd + filePath)
+	relativeFilePath, _ = GetRelativePath(cwd + filePath)
 
-	if relativeFilePath != "."+filePath {
-		t.Error("Expected the relative filePath to match")
+	if relativeFilePath != "bin/ec" {
+		t.Errorf("GetRelativePath(%s): expected: %v, got: %v", cwd+filePath, "bin/ec", relativeFilePath)
 	}
 
 	DIR := "/tmp/stuff"
@@ -96,6 +103,12 @@ func TestGetRelativePath(t *testing.T) {
 	err = os.Chdir(DIR)
 	if err != nil {
 		panic(err)
+	}
+
+	// Check with the current directory ("/tmp/stuff") in the middle of the given file path
+	relativeFilePath, _ = GetRelativePath("/foo" + DIR + filePath)
+	if relativeFilePath != "../../foo"+DIR+filePath {
+		t.Errorf("GetRelativePath(%s): expected: %v, got: %v", "/foo"+DIR+filePath, "../../foo"+DIR+filePath, relativeFilePath)
 	}
 
 	err = os.Remove(DIR)


### PR DESCRIPTION
This addresses the issue raised in #121 where the path returned by `GetRelativePath()` is wrong when given paths that are already relative. In addition, it now correctly handles files outside the current working directory using [Go's built-in `filepath.Rel()` function](https://golang.org/pkg/path/filepath/#Rel)

closes #121 