### PR TITLE
Update max_line_length validator to work with UTF8, fixes #115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+* Fix `max_line_length` validation for UTF-8 [#115](https://github.com/editorconfig-checker/editorconfig-checker/issues/115)
 ### Security
 ### Misc
 

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -139,7 +139,9 @@ func ValidateMaxLineLength(fileInformation files.FileInformation, config config.
 		return error.ValidationError{}
 	}
 
-	if currentError := validators.MaxLineLength(fileInformation.Line, maxLineLength); !config.Disable.MaxLineLength && currentError != nil {
+	charSet := fileInformation.Editorconfig.Raw["charset"]
+
+	if currentError := validators.MaxLineLength(fileInformation.Line, maxLineLength, charSet); !config.Disable.MaxLineLength && currentError != nil {
 		config.Logger.Verbose(fmt.Sprintf("Max line length error found in %s on %d", fileInformation.FilePath, fileInformation.LineNumber))
 		return error.ValidationError{LineNumber: -1, Message: currentError}
 	}

--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
 	"github.com/editorconfig-checker/editorconfig-checker/pkg/utils"
@@ -141,8 +142,19 @@ func LineEnding(fileContent string, endOfLine string) error {
 	return nil
 }
 
-func MaxLineLength(line string, maxLineLength int) error {
-	length := len(line)
+func MaxLineLength(line string, maxLineLength int, charSet string) error {
+	var length int
+	if charSet == "utf-8" || charSet == "utf-8-bom" {
+		if charSet == "utf-8-bom" && strings.HasPrefix(line, "\xEF\xBB\xBF") {
+			line = line[3:] //strip BOM
+		}
+		length = utf8.RuneCountInString(line)
+	} else {
+		// TODO: Handle utf-16be and utf-16le properly. Unfortunately, Go doesn't provide a utf16.RuneCountinString() function
+		// Just go with byte count
+		length = len(line)
+	}
+
 	if length > maxLineLength {
 		return fmt.Errorf("Line too long (%d instead of %d)", length, maxLineLength)
 	}

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -244,16 +244,21 @@ func TestMaxLineLength(t *testing.T) {
 	maxLineLengthTest := []struct {
 		line          string
 		maxLineLength int
+		charSet       string
 		expected      error
 	}{
-		{"", 80, nil},
-		{"abc", 2, errors.New("Line too long (3 instead of 2)")},
-		{"   ", 2, errors.New("Line too long (3 instead of 2)")},
-		{"xx", 2, nil},
+		{"検索は次の", 5, "utf-8", nil},
+		{"検索は次の", 2, "utf-8", errors.New("Line too long (5 instead of 2)")},
+		{"\xEF\xBB\xBF検索は次の", 5, "utf-8-bom", nil},
+		{"検索は次の", 5, "latin1", errors.New("Line too long (15 instead of 5)")},
+		{"", 80, "latin1", nil},
+		{"abc", 2, "latin1", errors.New("Line too long (3 instead of 2)")},
+		{"   ", 2, "latin1", errors.New("Line too long (3 instead of 2)")},
+		{"xx", 2, "latin1", nil},
 	}
 
 	for _, tt := range maxLineLengthTest {
-		actual := MaxLineLength(tt.line, tt.maxLineLength)
+		actual := MaxLineLength(tt.line, tt.maxLineLength, tt.charSet)
 		if !reflect.DeepEqual(actual, tt.expected) {
 			t.Errorf("Max(%s, %v): expected: %v, got: %v", tt.line, tt.maxLineLength, tt.expected, actual)
 		}


### PR DESCRIPTION
This fixes the `max_line_length` validator so it's charset-aware. For utf-8, it will now use the rune count in the string instead of the byte count, which fixes #115. Unfortunately, I couldn't figure out how to easily add support for UTF-16 because the "unicode/utf16" package doesn't provide a `RuneCountInString` method.