### PR TITLE
Fix TODO for insert_final_newline validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Deprecated
 ### Removed
 ### Fixed
+* Fix `insert_final_newline=true` validation when file ends with CRLF [#130](https://github.com/editorconfig-checker/editorconfig-checker/pull/130)
 ### Security
 ### Misc
 

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -106,6 +106,7 @@ func TestValidateFile(t *testing.T) {
 
 	configuration = config.Config{Verbose: true}
 	configuration.Disable.EndOfLine = true
+	configuration.Disable.InsertFinalNewline = true
 	result = ValidateFile("./../../testfiles/wrong-line-ending.txt", configuration)
 	if len(result) != 0 {
 		t.Error("Should have no error, got", result)

--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -94,10 +94,8 @@ func TrailingWhitespace(line string, trimTrailingWhitespace bool) error {
 // FinalNewline validates if a file has a final and correct newline
 func FinalNewline(fileContent string, insertFinalNewline string, endOfLine string) error {
 	if insertFinalNewline == "true" {
-		regexpPattern := fmt.Sprintf("%s$", utils.GetEolChar(endOfLine))
-		matched, _ := regexp.MatchString(regexpPattern, fileContent)
-
-		if !matched {
+		expectedEolChar := utils.GetEolChar(endOfLine)
+		if !strings.HasSuffix(fileContent, expectedEolChar) || (expectedEolChar == "\n" && strings.HasSuffix(fileContent, "\r\n")) {
 			return errors.New("Wrong line endings or new final newline")
 		}
 	} else if insertFinalNewline == "false" {

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -29,8 +29,7 @@ func TestFinalNewline(t *testing.T) {
 		{"x\r", "true", "lf", errors.New("Wrong line endings or new final newline")},
 		{"x\r", "true", "crlf", errors.New("Wrong line endings or new final newline")},
 
-		// TODO: Needs a fix (\n is the last char so it somehow matches)
-		// {"x\r\n", "true", "lf", errors.New("Wrong line endings or new final newline")},
+		{"x\r\n", "true", "lf", errors.New("Wrong line endings or new final newline")},
 		{"x\r\n", "true", "cr", errors.New("Wrong line endings or new final newline")},
 
 		// insert_final_newline false


### PR DESCRIPTION
This resolves the TODO comment in `validators_test.go` for when `insert_final_newline=true`, `end_of_line=lf`, and the file ends with `\r\n`. To fix this, I added a check to `FinalNewline()`, and updated it to use `strings.HasSuffix()` for simplicity.