### PR TITLE
Ignore patch files by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ If you don't pass the `ignore-defaults` flag to the binary these files are exclu
 "\\.7z$",
 "\\.bz2$",
 "\\.log$",
+"\\.patch$",
 "\\.css\\.map$",
 "\\.js\\.map$",
 "min\\.css$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ var defaultExcludes = []string{
 	"\\.7z$",
 	"\\.bz2$",
 	"\\.log$",
+	"\\.patch$",
 	"\\.css\\.map$",
 	"\\.js\\.map$",
 	"min\\.css$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|yarn\.lock$|package-lock\.json|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|yarn\.lock$|package-lock\.json|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
I know you may be hesitant to let the default exclude list grow, but patch files are common in repositories and definitely should never be checked for editorconfig violations.

I am aware that I can use .ecrc or CLI options to explicitly exclude them (which I have in my repos).

Thanks!