### PR TITLE
Instead of git ls-tree use filepath.Walk

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,8 @@ var defaultExcludes = []string{
 	"\\.js\\.map$",
 	"min\\.css$",
 	"min\\.js$",
+	"(^|/)\\.git($|/)",
+	"(^|/)node_modules($|/)",
 }
 
 var defaultAllowedContentTypes = []string{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|yarn\.lock$|package-lock\.json|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|yarn\.lock$|package-lock\.json|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$|(^|/)\.git($|/)|(^|/)node_modules($|/)`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
Currently files must be added to git index to be verified.

I do not like the `git` dependency therefor removed it completely and used `filepath.Walk` instead.
What if i dont have git installed, what if i use a different version control system?

I remove the `git ls-tree` command and used `filepath.Walk` instead.
In my opinion its a breaking change, so be careful!