### PR TITLE
Replace git ls-tree with git ls-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Extended validation to staged and unadded files [#135](https://github.com/editorconfig-checker/editorconfig-checker/pull/135)
+
 ### Security
 
 ### Misc

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -91,7 +91,7 @@ func GetFiles(config config.Config) ([]string, error) {
 		return filePaths, nil
 	}
 
-	byteArray, err := exec.Command("git", "ls-tree", "-r", "--name-only", "HEAD").Output()
+	byteArray, err := exec.Command("git", "ls-files", "--cached", "--others", "--modified", "--exclude-standard").Output()
 	if err != nil {
 		// It is not a git repository.
 		cwd, err := os.Getwd()


### PR DESCRIPTION
`ls-tree` command returns all files in the git repository, ignoring all staged or newly added files.
`ls-files` adding those missing files.