### PR TITLE
Add modern image formats to default excludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Add WebP and AVIF to default excludes [#159](https://github.com/editorconfig-checker/editorconfig-checker/pull/159)
+
 ### Deprecated
 
 ### Removed

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,8 @@ var defaultExcludes = []string{
 	"\\.png$",
 	"\\.jpg$",
 	"\\.jpeg$",
+	"\\.webp$",
+	"\\.avif$",
 	"\\.mp4$",
 	"\\.wmv$",
 	"\\.svg$",


### PR DESCRIPTION
There are some modern image formats for the web I use every day. It's AVIF and WEBP. `editorconfig-checker` checks them so I turned them off with `-exclude`. But it seems it should be the default behaviour.