### PR TITLE
feat: Exclude yarn 2 files by default (#170).

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,12 @@ add x y =
 
 If you don't pass the `ignore-defaults` flag to the binary these files are excluded automatically:
 ```
+"\\.yarn/",
 "yarn\\.lock$",
 "package-lock\\.json$",
 "composer\\.lock$",
+"\\.pnp\\.cjs$",
+"\\.pnp\\.js$",
 "\\.snap$",
 "\\.otf$",
 "\\.woff$",

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ add x y =
 If you don't pass the `ignore-defaults` flag to the binary these files are excluded automatically:
 ```
 "yarn\\.lock$",
-"package-lock\\.json",
+"package-lock\\.json$",
 "composer\\.lock$",
 "\\.snap$",
 "\\.otf$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,9 +16,12 @@ var DefaultExcludes = strings.Join(defaultExcludes, "|")
 
 // defaultExcludes are an array to produce the correct string from
 var defaultExcludes = []string{
+	"\\.yarn/",
 	"yarn\\.lock$",
 	"package-lock\\.json$",
 	"composer\\.lock$",
+	"\\.pnp\\.cjs$",
+	"\\.pnp\\.js$",
 	"\\.snap$",
 	"\\.otf$",
 	"\\.woff$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ var DefaultExcludes = strings.Join(defaultExcludes, "|")
 // defaultExcludes are an array to produce the correct string from
 var defaultExcludes = []string{
 	"yarn\\.lock$",
-	"package-lock\\.json",
+	"package-lock\\.json$",
 	"composer\\.lock$",
 	"\\.snap$",
 	"\\.otf$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|yarn\.lock$|package-lock\.json|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|yarn\.lock$|package-lock\.json$|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|yarn\.lock$|package-lock\.json$|composer\.lock$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|\.yarn/|yarn\.lock$|package-lock\.json$|composer\.lock$|\.pnp\.cjs$|\.pnp\.js$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
feat: Exclude yarn 2 files by default (#170). Add .yarn/, .pnp.cjs, and .pnp.js to the default excludes.

fix: Add $ to default exclude package-lock.json. This is more consistent with the rest of the default exclude patterns.