### PR TITLE
Remove `git` in Dockerfile final stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-X main.version=$(cat VERSIO
 
 FROM alpine:latest
 
-RUN apk add --no-cache git
 WORKDIR /check/
 COPY --from=build /ec/bin/ec /usr/bin
 


### PR DESCRIPTION
Looks like there is no need to have additional git dependency