### PR TITLE
fix: support empty `end_of_line` in `FinalNewline`

### DIFF
--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -94,17 +94,21 @@ func TrailingWhitespace(line string, trimTrailingWhitespace bool) error {
 
 // FinalNewline validates if a file has a final and correct newline
 func FinalNewline(fileContent string, insertFinalNewline string, endOfLine string) error {
-	if insertFinalNewline == "true" {
+	if endOfLine != "" && insertFinalNewline == "true" {
 		expectedEolChar := utils.GetEolChar(endOfLine)
 		if !strings.HasSuffix(fileContent, expectedEolChar) || (expectedEolChar == "\n" && strings.HasSuffix(fileContent, "\r\n")) {
 			return errors.New("Wrong line endings or new final newline")
 		}
-	} else if insertFinalNewline == "false" {
+	} else {
 		regexpPattern := "(\n|\r|\r\n)$"
-		matched, _ := regexp.MatchString(regexpPattern, fileContent)
+		hasFinalNewline, _ := regexp.MatchString(regexpPattern, fileContent)
 
-		if matched {
+		if insertFinalNewline == "false" && hasFinalNewline {
 			return errors.New("No final newline expected")
+		}
+
+		if insertFinalNewline == "true" && !hasFinalNewline {
+			return errors.New("Final newline expected")
 		}
 	}
 

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -61,6 +61,16 @@ func TestFinalNewline(t *testing.T) {
 		{"x\r\n", "", "lf", nil},
 		{"x\r\n", "", "cr", nil},
 		{"x\r\n", "", "crlf", nil},
+
+		// end_of_line not set
+		{"x", "true", "", errors.New("Final newline expected")},
+		{"x", "false", "", nil},
+		{"x\n", "true", "", nil},
+		{"x\n", "false", "", errors.New("No final newline expected")},
+		{"x\r", "true", "", nil},
+		{"x\r", "false", "", errors.New("No final newline expected")},
+		{"x\r\n", "true", "", nil},
+		{"x\r\n", "false", "", errors.New("No final newline expected")},
 	}
 
 	for _, tt := range finalNewlineTests {


### PR DESCRIPTION
`utils.GetEolChar(endOfLine)` returns `\n` when `end_of_line` is not defined. This default contradicts the default `\r\n` line ending used in windows.

`FinalNewline` was requiring the final newline to be this default `\n` (unless otherwise defined), causing unexpected errors using windows default `\r\n` line endings.

This change removes the default validation against `\n`, and only validates against `end_of_line` when it is set.

Fixes: #164 