### PR TITLE
docs: fix spelling of whether

### DIFF
--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -136,7 +136,7 @@ func main() {
 	os.Exit(0)
 }
 
-// ReturnableFlags returns wether a flag passed should exit the program
+// ReturnableFlags returns whether a flag passed should exit the program
 func ReturnableFlags(config config.Config) bool {
 	switch {
 	case config.ShowVersion:

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -26,7 +26,7 @@ type FileInformation struct {
 	Editorconfig *editorconfig.Definition
 }
 
-// IsExcluded returns wether the file is excluded via arguments or config file
+// IsExcluded returns whether the file is excluded via arguments or config file
 func IsExcluded(filePath string, config config.Config) (bool, error) {
 	if len(config.Exclude) == 0 && config.IgnoreDefaults {
 		return false, nil
@@ -174,7 +174,7 @@ func GetContentType(path string) (string, error) {
 	return http.DetectContentType(buffer), nil
 }
 
-// PathExists checks wether a path of a file or directory exists or not
+// PathExists checks whether a path of a file or directory exists or not
 func PathExists(filePath string) bool {
 	absolutePath, _ := filepath.Abs(filePath)
 	_, err := os.Stat(absolutePath)
@@ -197,7 +197,7 @@ func GetRelativePath(filePath string) (string, error) {
 	return filepath.Rel(cwd, filePath)
 }
 
-// IsAllowedContentType returns wether the contentType is
+// IsAllowedContentType returns whether the contentType is
 // an allowed content type to check or not
 func IsAllowedContentType(contentType string, config config.Config) bool {
 	result := false

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,21 +22,21 @@ func GetEolChar(endOfLine string) string {
 	return "\n"
 }
 
-// IsRegularFile returns wether a file is a regular file or not
+// IsRegularFile returns whether a file is a regular file or not
 func IsRegularFile(filePath string) bool {
 	absolutePath, firstErr := filepath.Abs(filePath)
 	fi, secondErr := os.Stat(absolutePath)
 	return firstErr == nil && secondErr == nil && fi.Mode().IsRegular()
 }
 
-// IsDirectory returns wether a file is a directory or not
+// IsDirectory returns whether a file is a directory or not
 func IsDirectory(filePath string) bool {
 	absolutePath, firstErr := filepath.Abs(filePath)
 	fi, secondErr := os.Stat(absolutePath)
 	return firstErr == nil && secondErr == nil && fi.Mode().IsDir()
 }
 
-// FileExists returns wether a file exists or not
+// FileExists returns whether a file exists or not
 func FileExists(filePath string) bool {
 	absolutePath, _ := filepath.Abs(filePath)
 	fi, secondErr := os.Stat(absolutePath)


### PR DESCRIPTION
Fixes comment typos of [wether](https://www.merriam-webster.com/dictionary/wether) to [whether](https://www.merriam-webster.com/dictionary/whether) to help improve readability.