### PR TITLE
feat: add Cargo.lock (Rust) to default excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ If you don't pass the `ignore-defaults` flag to the binary these files are exclu
 "yarn\\.lock$",
 "package-lock\\.json$",
 "composer\\.lock$",
+"Cargo\\.lock$",
 "\\.pnp\\.cjs$",
 "\\.pnp\\.js$",
 "\\.snap$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ var defaultExcludes = []string{
 	"yarn\\.lock$",
 	"package-lock\\.json$",
 	"composer\\.lock$",
+	"Cargo\\.lock$",
 	"\\.pnp\\.cjs$",
 	"\\.pnp\\.js$",
 	"\\.snap$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|\.yarn/|yarn\.lock$|package-lock\.json$|composer\.lock$|\.pnp\.cjs$|\.pnp\.js$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|\.yarn/|yarn\.lock$|package-lock\.json$|composer\.lock$|Cargo\.lock$|\.pnp\.cjs$|\.pnp\.js$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
Hey! :wave:

`Cargo.lock` is the file like `package-lock.json` but for [Rust](https://www.rust-lang.org/).
It should be ignored by default as with others files from others packages managers.