### PR TITLE
feat: Exclude `.pnp.loader.mjs` by default (#201)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ If you don't pass the `ignore-defaults` flag to the binary these files are exclu
 "^Cargo\\.lock$",
 "^\\.pnp\\.cjs$",
 "^\\.pnp\\.js$",
+"^\\.pnp\\.loader\\.mjs$",
 "\\.snap$",
 "\\.otf$",
 "\\.woff$",

--- a/README.md
+++ b/README.md
@@ -2,27 +2,27 @@
 
 <a href="https://www.buymeacoffee.com/mstruebing" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 
-[![Build Status](https://travis-ci.org/editorconfig-checker/editorconfig-checker.svg?branch=master)](https://travis-ci.org/editorconfig-checker/editorconfig-checker) 
+[![Build Status](https://travis-ci.org/editorconfig-checker/editorconfig-checker.svg?branch=master)](https://travis-ci.org/editorconfig-checker/editorconfig-checker)
 [![codecov](https://codecov.io/gh/editorconfig-checker/editorconfig-checker/branch/master/graph/badge.svg)](https://codecov.io/gh/editorconfig-checker/editorconfig-checker)
 [![Hits-of-Code](https://hitsofcode.com/github/editorconfig-checker/editorconfig-checker)](https://hitsofcode.com/view/github/editorconfig-checker/editorconfig-checker)
 [![Go Report Card](https://goreportcard.com/badge/github.com/editorconfig-checker/editorconfig-checker)](https://goreportcard.com/report/github.com/editorconfig-checker/editorconfig-checker)
 
 ![Logo](https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/master/docs/logo.png "Logo")
 
-1. [What](#what)  
-2. [Quickstart](#quickstart)  
-3. [Installation](#installation)  
-4. [Usage](#usage)  
-5. [Configuration](#configuration)  
-6. [Excluding](#excluding)  
-6.1 [Excluding Lines](#excluding-lines)  
-6.2 [Excluding Files](#excluding-files)  
-6.2.1 [Inline](#inline)  
-6.2.2 [Default Excludes](#default-excludes)  
-6.2.3 [Manually Excluding](#manually-excluding)  
-6.2.4 [via configuration](#via-configuration)  
-6.2.5 [via arguments](#via-arguments)  
-6.2.6 [Generally](#generally)  
+1. [What](#what)
+2. [Quickstart](#quickstart)
+3. [Installation](#installation)
+4. [Usage](#usage)
+5. [Configuration](#configuration)
+6. [Excluding](#excluding)
+6.1 [Excluding Lines](#excluding-lines)
+6.2 [Excluding Files](#excluding-files)
+6.2.1 [Inline](#inline)
+6.2.2 [Default Excludes](#default-excludes)
+6.2.3 [Manually Excluding](#manually-excluding)
+6.2.4 [via configuration](#via-configuration)
+6.2.5 [via arguments](#via-arguments)
+6.2.6 [Generally](#generally)
 7. [Docker](#docker)
 8. [Continuous Integration](#continous-integration)
 8. [Support](#support)
@@ -32,8 +32,8 @@
 
 ![Example Screenshot](https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/master/docs/screenshot.png "Example Screenshot")
 
-This is a tool to check if your files consider your `.editorconfig`-rules. 
-Most tools - like linters for example - only test one filetype and need an extra configuration. 
+This is a tool to check if your files consider your `.editorconfig`-rules.
+Most tools - like linters for example - only test one filetype and need an extra configuration.
 This tool only needs your `.editorconfig` to check all files.
 
 If you don't know about editorconfig already you can read about it here: [editorconfig.org](https://editorconfig.org/).
@@ -62,9 +62,9 @@ tar xzf ec-$OS-$ARCH.tar.gz && \
 
 ## Installation
 
-Grab a binary from the [release page](https://github.com/editorconfig-checker/editorconfig-checker/releases). 
+Grab a binary from the [release page](https://github.com/editorconfig-checker/editorconfig-checker/releases).
 
-If you have go installed you can run `go get github.com/editorconfig-checker/editorconfig-checker` and run `make build` inside the project folder. 
+If you have go installed you can run `go get github.com/editorconfig-checker/editorconfig-checker` and run `make build` inside the project folder.
 This will place a binary called `ec` into the `bin` directory.
 
 If you are using Arch Linux, you can use [pacman](https://wiki.archlinux.org/title/Pacman) to install from [community repository](https://archlinux.org/packages/community/x86_64/editorconfig-checker/):
@@ -172,7 +172,7 @@ You can exclude single lines inline. To do that you need a comment on that line 
 
 ```js
 const myTemplateString = `
-  first line 
+  first line
      wrongly indended line because it needs to be` // editorconfig-checker-disable-line
 ```
 
@@ -183,7 +183,7 @@ To temporarily disable all checks, add a comment containing `editorconfig-checke
 ```js
 // editorconfig-checker-disable
 const myTemplateString = `
-  first line 
+  first line
      wrongly indended line because it needs to be
 `
 // editorconfig-checker-enable
@@ -195,7 +195,7 @@ const myTemplateString = `
 
 If you want to exclude a file inline you need a comment on the first line of the file that contains: `editorconfig-checker-disable-file`
 
-```hs 
+```hs
 -- editorconfig-checker-disable-file
 add :: Int -> Int -> Int
 add x y =
@@ -286,7 +286,7 @@ If you want to see which files the tool would check without checking them you ca
 
 Note that while `--dry-run` outputs absolute paths, a regular expression matches on relative paths from where the `ec` command is used.
 
-## Docker 
+## Docker
 
 You are able to run this tool inside a Docker container.
 To do this you need to have Docker installed and run this command in your repository root which you want to check:
@@ -310,7 +310,7 @@ ENABLE:
 ```
 
 ## Support
-If you have any questions, suggestions, need a wrapper for a programming language or just want to chat join #editorconfig-checker on 
+If you have any questions, suggestions, need a wrapper for a programming language or just want to chat join #editorconfig-checker on
 freenode(IRC).
-If you don't have an IRC-client set up you can use the 
+If you don't have an IRC-client set up you can use the
 [freenode webchat](https://webchat.freenode.net/?channels=editorconfig-checker).

--- a/README.md
+++ b/README.md
@@ -207,13 +207,13 @@ add x y =
 
 If you don't pass the `ignore-defaults` flag to the binary these files are excluded automatically:
 ```
-"\\.yarn/",
-"yarn\\.lock$",
-"package-lock\\.json$",
-"composer\\.lock$",
-"Cargo\\.lock$",
-"\\.pnp\\.cjs$",
-"\\.pnp\\.js$",
+"^\\.yarn/",
+"^yarn\\.lock$",
+"^package-lock\\.json$",
+"^composer\\.lock$",
+"^Cargo\\.lock$",
+"^\\.pnp\\.cjs$",
+"^\\.pnp\\.js$",
 "\\.snap$",
 "\\.otf$",
 "\\.woff$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,13 +16,13 @@ var DefaultExcludes = strings.Join(defaultExcludes, "|")
 
 // defaultExcludes are an array to produce the correct string from
 var defaultExcludes = []string{
-	"\\.yarn/",
-	"yarn\\.lock$",
-	"package-lock\\.json$",
-	"composer\\.lock$",
-	"Cargo\\.lock$",
-	"\\.pnp\\.cjs$",
-	"\\.pnp\\.js$",
+	"^\\.yarn/",
+	"^yarn\\.lock$",
+	"^package-lock\\.json$",
+	"^composer\\.lock$",
+	"^Cargo\\.lock$",
+	"^\\.pnp\\.cjs$",
+	"^\\.pnp\\.js$",
 	"\\.snap$",
 	"\\.otf$",
 	"\\.woff$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ var defaultExcludes = []string{
 	"^Cargo\\.lock$",
 	"^\\.pnp\\.cjs$",
 	"^\\.pnp\\.js$",
+	"^\\.pnp\\.loader\\.mjs$",
 	"\\.snap$",
 	"\\.otf$",
 	"\\.woff$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|\.yarn/|yarn\.lock$|package-lock\.json$|composer\.lock$|Cargo\.lock$|\.pnp\.cjs$|\.pnp\.js$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
Fixes #201. This file is auto-generated by Yarn v3.1.0+.

fix: Add `^` to default excludes of specific files. Unlike most of the default excludes, which are for filetypes, `.yarn/`, `yarn.lock`, `package-lock.json`, `composer.lock`, `Cargo.lock`, `.pnp.cjs`, and `.pnp.js` are the full filenames of auto-generated files and folders. Hence, match the filenames exactly rather than excluding any filename ending in them.

docs: Trim trailing whitespace in README.