### PR TITLE
fix: restore accidentally deleted line

### DIFF
--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -143,6 +143,8 @@ func ReadLines(content string) []string {
 
 // GetContentType returns the content type of a file
 func GetContentType(path string, config config.Config) (string, error) {
+	fileStat, err := os.Stat(path)
+
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
I don't know how that happened. I could blame the Nano editor, but I'm sure it's operator error....

Fixes https://github.com/editorconfig-checker/editorconfig-checker/runs/7391616577?check_suite_focus=true#step:7:16