### PR TITLE
fix: add missing text content types to validator

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,6 +56,7 @@ var defaultExcludes = []string{
 	"min\\.js$",
 }
 
+// keep synced with pkg/validation/validation.go#L20
 var defaultAllowedContentTypes = []string{
 	"text/",
 	"application/octet-stream",

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -17,11 +17,14 @@ import (
 	"github.com/editorconfig-checker/editorconfig-checker/pkg/validation/validators"
 )
 
+// keep synced with /pkg/config/config.go#L59
 var textRegexes = []string{
 	"^text/",
 	"^application/ecmascript$",
 	"^application/json$",
+	"^application/x-ndjson$",
 	"^application/xml$",
+	"+json",
 	"+xml$",
 }
 


### PR DESCRIPTION
Somehow, I got these two lists out of sync. Would you be open to my rewriting this so there is just a single list, containing the regexs, and we strip out the metacharacters for
https://github.com/editorconfig-checker/editorconfig-checker/blob/ec3af1e38f494ed0ae96f9d0ee2d4d14f75d3f65/pkg/config/config.go#L109
?