### PR TITLE
fix: Fix typo in final EOL check error message

### DIFF
--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -97,7 +97,7 @@ func FinalNewline(fileContent string, insertFinalNewline string, endOfLine strin
 	if endOfLine != "" && insertFinalNewline == "true" {
 		expectedEolChar := utils.GetEolChar(endOfLine)
 		if !strings.HasSuffix(fileContent, expectedEolChar) || (expectedEolChar == "\n" && strings.HasSuffix(fileContent, "\r\n")) {
-			return errors.New("Wrong line endings or new final newline")
+			return errors.New("Wrong line endings or no final newline")
 		}
 	} else {
 		regexpPattern := "(\n|\r|\r\n)$"

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -19,18 +19,18 @@ func TestFinalNewline(t *testing.T) {
 		{"x\r", "true", "cr", nil},
 		{"x\r\n", "true", "crlf", nil},
 
-		{"x", "true", "lf", errors.New("Wrong line endings or new final newline")},
-		{"x", "true", "cr", errors.New("Wrong line endings or new final newline")},
-		{"x", "true", "crlf", errors.New("Wrong line endings or new final newline")},
+		{"x", "true", "lf", errors.New("Wrong line endings or no final newline")},
+		{"x", "true", "cr", errors.New("Wrong line endings or no final newline")},
+		{"x", "true", "crlf", errors.New("Wrong line endings or no final newline")},
 
-		{"x\n", "true", "cr", errors.New("Wrong line endings or new final newline")},
-		{"x\n", "true", "crlf", errors.New("Wrong line endings or new final newline")},
+		{"x\n", "true", "cr", errors.New("Wrong line endings or no final newline")},
+		{"x\n", "true", "crlf", errors.New("Wrong line endings or no final newline")},
 
-		{"x\r", "true", "lf", errors.New("Wrong line endings or new final newline")},
-		{"x\r", "true", "crlf", errors.New("Wrong line endings or new final newline")},
+		{"x\r", "true", "lf", errors.New("Wrong line endings or no final newline")},
+		{"x\r", "true", "crlf", errors.New("Wrong line endings or no final newline")},
 
-		{"x\r\n", "true", "lf", errors.New("Wrong line endings or new final newline")},
-		{"x\r\n", "true", "cr", errors.New("Wrong line endings or new final newline")},
+		{"x\r\n", "true", "lf", errors.New("Wrong line endings or no final newline")},
+		{"x\r\n", "true", "cr", errors.New("Wrong line endings or no final newline")},
 
 		// insert_final_newline false
 		{"x", "false", "lf", nil},


### PR DESCRIPTION
I think the intention of this error message is to show the absence of a final newline, so `no` makes much more sense than `new` to me.