### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Hits-of-Code](https://hitsofcode.com/github/editorconfig-checker/editorconfig-checker)](https://hitsofcode.com/view/github/editorconfig-checker/editorconfig-checker)
 [![Go Report Card](https://goreportcard.com/badge/github.com/editorconfig-checker/editorconfig-checker)](https://goreportcard.com/report/github.com/editorconfig-checker/editorconfig-checker)
 
-![Logo](https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/main/docs/logo.png "Logo")
+![Logo](docs/logo.png)
 
 1. [What](#what)
 2. [Quickstart](#quickstart)
@@ -15,43 +15,44 @@
 4. [Usage](#usage)
 5. [Configuration](#configuration)
 6. [Excluding](#excluding)
-6.1 [Excluding Lines](#excluding-lines)
-6.2 [Excluding Files](#excluding-files)
-6.2.1 [Inline](#inline)
-6.2.2 [Default Excludes](#default-excludes)
-6.2.3 [Manually Excluding](#manually-excluding)
-6.2.4 [via configuration](#via-configuration)
-6.2.5 [via arguments](#via-arguments)
-6.2.6 [Generally](#generally)
+   6.1 [Excluding Lines](#excluding-lines)
+   6.2 [Excluding Files](#excluding-files)
+   6.2.1 [Inline](#inline)
+   6.2.2 [Default Excludes](#default-excludes)
+   6.2.3 [Manually Excluding](#manually-excluding)
+   6.2.4 [via configuration](#via-configuration)
+   6.2.5 [via arguments](#via-arguments)
+   6.2.6 [Generally](#generally)
 7. [Docker](#docker)
 8. [Continuous Integration](#continous-integration)
-8. [Support](#support)
-
+9. [Support](#support)
 
 ## What?
 
-![Example Screenshot](https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/main/docs/screenshot.png "Example Screenshot")
+![Example Screenshot](docs/screenshot.png)
 
-This is a tool to check if your files consider your `.editorconfig`-rules.
-Most tools - like linters for example - only test one filetype and need an extra configuration.
+This is a tool to check if your files consider your `.editorconfig` rules.
+Most tools—like linters for example—only test one filetype and need an extra configuration.
 This tool only needs your `.editorconfig` to check all files.
 
 If you don't know about editorconfig already you can read about it here: [editorconfig.org](https://editorconfig.org/).
 
 Currently implemented editorconfig features are:
-* `end_of_line`
-* `insert_final_newline`
-* `trim_trailing_whitespace`
-* `indent_style`
-* `indent_size`
-* `max_line_length`
+
+- `end_of_line`
+- `insert_final_newline`
+- `trim_trailing_whitespace`
+- `indent_style`
+- `indent_size`
+- `max_line_length`
 
 Unsupported features are:
-* `charset`
+
+- `charset`
 
 ## Quickstart
 
-```bash
+```shell
 VERSION="2.6.0"
 OS="linux"
 ARCH="amd64"
@@ -69,14 +70,14 @@ This will place a binary called `ec` into the `bin` directory.
 
 If you are using Arch Linux, you can use [pacman](https://wiki.archlinux.org/title/Pacman) to install from [community repository](https://archlinux.org/packages/community/x86_64/editorconfig-checker/):
 
-```
+```shell
 pacman -S editorconfig-checker
 ```
 
 Also, development (VCS) package is available in the [AUR](https://aur.archlinux.org/packages/editorconfig-checker-git):
 
-```
-<favourite-aur-helper> <install-command> editorconfig-checker-git
+```shell
+# <favourite-aur-helper> <install-command> editorconfig-checker-git
 
 # i.e.
 paru -S editorconfig-checker-git
@@ -84,7 +85,7 @@ paru -S editorconfig-checker-git
 
 If go 1.16 or greater is installed, you can also install it globally via `go install`:
 
-```bash
+```shell
 go install github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest
 ```
 
@@ -182,7 +183,7 @@ By default the allowed_content_types are:
 
 You can exclude single lines inline. To do that you need a comment on that line that says: `editorconfig-checker-disable-line`.
 
-```js
+```javascript
 const myTemplateString = `
   first line
      wrongly indended line because it needs to be` // editorconfig-checker-disable-line
@@ -192,7 +193,7 @@ const myTemplateString = `
 
 To temporarily disable all checks, add a comment containing `editorconfig-checker-disable`. Re-enable with a comment containing `editorconfig-checker-enable`
 
-```js
+```javascript
 // editorconfig-checker-disable
 const myTemplateString = `
   first line
@@ -207,7 +208,7 @@ const myTemplateString = `
 
 If you want to exclude a file inline you need a comment on the first line of the file that contains: `editorconfig-checker-disable-file`
 
-```hs
+```haskell
 -- editorconfig-checker-disable-file
 add :: Int -> Int -> Int
 add x y =
@@ -218,6 +219,7 @@ add x y =
 #### Default excludes
 
 If you don't pass the `ignore-defaults` flag to the binary these files are excluded automatically:
+
 ```
 "^\\.yarn/",
 "^yarn\\.lock$",
@@ -268,7 +270,7 @@ This will get merged with the default excludes (if not ignored). You should reme
 
 An `.ecrc` which would ignore all test files and all markdown files can look like this:
 
-```
+```json
 {
   "Verbose": false,
   "IgnoreDefaults": false,
@@ -287,7 +289,7 @@ An `.ecrc` which would ignore all test files and all markdown files can look lik
 
 ##### via arguments
 
-If you want to play around how the tool would behave you can also pass the `--exclude` argument to the binary. This will accept a regular expression as well. If you use this argument the default excludes as well as the excludes from the `.ecrc`-file will merged together.
+If you want to play around how the tool would behave you can also pass the `--exclude` argument to the binary. This will accept a regular expression as well. If you use this argument the default excludes as well as the excludes from the `.ecrc` file will merged together.
 
 For example: `ec --exclude node_modules`
 
@@ -311,19 +313,18 @@ Dockerhub: [mstruebing/editorconfig-checker](https://hub.docker.com/r/mstruebing
 
 ### Mega-Linter
 
-Instead of installing and configuring `editorconfig-checker` and all other linters in your project CI workflows (GitHub Actions & others), you can use [Mega-Linter](https://nvuillam.github.io/mega-linter/) which does all that for you with a single [assisted installation](https://nvuillam.github.io/mega-linter/installation/)
+Instead of installing and configuring `editorconfig-checker` and all other linters in your project CI workflows (GitHub Actions & others), you can use [Mega-Linter](https://nvuillam.github.io/mega-linter/) which does all that for you with a single [assisted installation](https://nvuillam.github.io/mega-linter/installation/).
 
-Mega-Linter embeds [editorconfig-checker](https://nvuillam.github.io/mega-linter/descriptors/editorconfig_editorconfig_checker/) by default in all its [flavors](https://nvuillam.github.io/mega-linter/flavors/), meaning that it will be run at each commit or Pull Request to detect any issue related to .`editorconfig`
+Mega-Linter embeds [editorconfig-checker](https://nvuillam.github.io/mega-linter/descriptors/editorconfig_editorconfig_checker/) by default in all its [flavors](https://nvuillam.github.io/mega-linter/flavors/), meaning that it will be run at each commit or Pull Request to detect any issue related to `.editorconfig`.
 
-If you want to use only `editorconfig-checker` and not the 70+ other linters, you can use the following `.mega-linter.yml` configuration file
+If you want to use only `editorconfig-checker` and not the 70+ other linters, you can use the following `.mega-linter.yml` configuration file:
 
 ```yaml
 ENABLE:
-- EDITORCONFIG
+  - EDITORCONFIG
 ```
 
 ## Support
-If you have any questions, suggestions, need a wrapper for a programming language or just want to chat join #editorconfig-checker on
-freenode(IRC).
-If you don't have an IRC-client set up you can use the
-[freenode webchat](https://webchat.freenode.net/?channels=editorconfig-checker).
+
+If you have any questions, suggestions, need a wrapper for a programming language or just want to chat join #editorconfig-checker on freenode(IRC).
+If you don't have an IRC-client set up you can use the [freenode webchat](https://webchat.freenode.net/?channels=editorconfig-checker).


### PR DESCRIPTION
* Use relative URL for internal references
* Remove redundant title from images
* Correct grammatical errors in "What?" section
* Specify and unalias info string (the language of the code block)
* Comment out illustrative installation command
* Add missing punctuation marks and fix typo in "Mega-Linter" section
* Format indentation, empty lines, and list markers