### PR TITLE
ci: add pull_request event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: wagoid/commitlint-github-action@v2.0.3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v5
         if: ${{ github.ref != 'refs/heads/main' }}
       - uses: actions/setup-go@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: "ci"
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -23,6 +24,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: EndBug/add-and-commit@v7
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           add: "CHANGELOG.md"
           message: "docs: add changelog [skip-ci]"


### PR DESCRIPTION
Hey! :wave:

Since https://github.com/editorconfig-checker/editorconfig-checker/commit/894c4c4f63471a406c935ffb87813544becec15d commit, Continuous Integration (CI) started failing.

This PR:
- Add `on.pull_request` so we can run CI on Pull Requests to avoid this kind of failure introduced in future PRs.