### PR TITLE
feat: add *.db files to default excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ If you don't pass the `ignore-defaults` flag to the binary these files are exclu
 "\\.bak$",
 "\\.bin$",
 "\\.pdf$",
+"\\.db$",
 "\\.zip$",
 "\\.gz$",
 "\\.tar$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ var defaultExcludes = []string{
 	"\\.bak$",
 	"\\.bin$",
 	"\\.pdf$",
+	"\\.db$",
 	"\\.zip$",
 	"\\.gz$",
 	"\\.tar$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -50,7 +50,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|testdata|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|testdata|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.db$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
Hey! :wave:
Thanks for this awesome tool. :smile:

This PR adds `.db` files to default excludes.
It should be ignored by default as it is often a binary file (e.g: `sqlite3`).
Even if is discouraged to commit this kind of file in a git repo, it sometimes makes sense for small projects to create this file with `sqlite3` with the tables of the database already created, and then once added, add this file to `.gitignore`, but at this moment, the file is already there and will be linted by `editorconfig-checker` but it doesn't make sense to check if `end_of_line` is respected for example. 