### PR TITLE
feat: Added functionality to output a more parsable format

### DIFF
--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -39,6 +39,7 @@ func init() {
 	flag.BoolVar(&c.ShowVersion, "version", false, "print the version number")
 	flag.BoolVar(&c.Help, "help", false, "print the help")
 	flag.BoolVar(&c.Help, "h", false, "print the help")
+	flag.BoolVar(&c.Parsable, "parsable", false, "output in a parsable format, also disables color")
 	flag.BoolVar(&c.Verbose, "verbose", false, "print debugging information")
 	flag.BoolVar(&c.Verbose, "v", false, "print debugging information")
 	flag.BoolVar(&c.Debug, "debug", false, "print debugging information")
@@ -124,7 +125,10 @@ func main() {
 
 	if errorCount != 0 {
 		error.PrintErrors(errors, config)
-		config.Logger.Error(fmt.Sprintf("\n%d errors found", errorCount))
+
+		if !config.Parsable {
+			config.Logger.Error(fmt.Sprintf("\n%d errors found", errorCount))
+		}
 	}
 
 	config.Logger.Verbose("%d files checked", len(filePaths))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,6 +78,7 @@ type Config struct {
 
 	// CONFIG FILE
 	Version             string
+	Parsable            bool
 	Verbose             bool
 	Debug               bool
 	IgnoreDefaults      bool
@@ -168,6 +169,10 @@ func (c *Config) Merge(config Config) {
 		c.NoColor = config.NoColor
 	}
 
+	if config.Parsable {
+		c.Parsable = config.Parsable
+	}
+
 	if config.IgnoreDefaults {
 		c.IgnoreDefaults = config.IgnoreDefaults
 	}
@@ -194,9 +199,9 @@ func (c *Config) Merge(config Config) {
 
 	c.mergeDisabled(config.Disable)
 	c.Logger = logger.Logger{
-		Verbosee: c.Verbose || config.Verbose,
-		Debugg:   c.Debug || config.Debug,
-		NoColor:  c.NoColor || config.NoColor}
+		Verbosee: c.Verbose,
+		Debugg:   c.Debug,
+		NoColor:  c.NoColor || c.Parsable}
 }
 
 // mergeDisabled merges the disabled checks into the config
@@ -245,6 +250,7 @@ func (c Config) Save(version string) error {
 	type writtenConfig struct {
 		Version             string
 		Verbose             bool
+		Parsable            bool
 		Debug               bool
 		IgnoreDefaults      bool
 		SpacesAftertabs     bool

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -171,7 +171,7 @@ func TestGetAsString(t *testing.T) {
 	_ = c.Parse()
 
 	actual := c.GetAsString()
-	expected := "Config: {ShowVersion:false Help:false DryRun:false Path:../../.ecrc Version:2.6.0 Verbose:false Debug:false IgnoreDefaults:false SpacesAftertabs:false NoColor:false Exclude:[testfiles testdata] AllowedContentTypes:[text/ application/octet-stream application/ecmascript application/json application/x-ndjson application/xml +json +xml] PassedFiles:[] Disable:{EndOfLine:false Indentation:false InsertFinalNewline:false TrimTrailingWhitespace:false IndentSize:false MaxLineLength:false} Logger:{Verbosee:false Debugg:false NoColor:false}}"
+	expected := "Config: {ShowVersion:false Help:false DryRun:false Path:../../.ecrc Version:2.6.0 Parsable:false Verbose:false Debug:false IgnoreDefaults:false SpacesAftertabs:false NoColor:false Exclude:[testfiles testdata] AllowedContentTypes:[text/ application/octet-stream application/ecmascript application/json application/x-ndjson application/xml +json +xml] PassedFiles:[] Disable:{EndOfLine:false Indentation:false InsertFinalNewline:false TrimTrailingWhitespace:false IndentSize:false MaxLineLength:false} Logger:{Verbosee:false Debugg:false NoColor:false}}"
 
 	if actual != expected {
 		t.Errorf("Expected: %v, got: %v ", expected, actual)

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -42,14 +42,24 @@ func PrintErrors(errors []ValidationErrors, config config.Config) {
 				continue
 			}
 
-			config.Logger.Warning(fmt.Sprintf("%s:", relativeFilePath))
-			for _, singleError := range fileErrors.Errors {
-				if singleError.LineNumber != -1 {
-					config.Logger.Error(fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message))
-				} else {
-					config.Logger.Error(fmt.Sprintf("\t%s", singleError.Message))
+			if config.Parsable {
+				for _, singleError := range fileErrors.Errors {
+					if singleError.LineNumber != -1 {
+						config.Logger.Error(fmt.Sprintf("%s:%d: %s", relativeFilePath, singleError.LineNumber, singleError.Message))
+					} else {
+						config.Logger.Error(fmt.Sprintf("%s: %s", relativeFilePath, singleError.Message))
+					}
 				}
+			} else {
+				config.Logger.Warning(fmt.Sprintf("%s:", relativeFilePath))
+				for _, singleError := range fileErrors.Errors {
+					if singleError.LineNumber != -1 {
+						config.Logger.Error(fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message))
+					} else {
+						config.Logger.Error(fmt.Sprintf("\t%s", singleError.Message))
+					}
 
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Introduced a `-parsable` flag that enables outputting in similar format as linters like `flake8`, `mdl`, `shellcheck --format gcc` and `yamllint -f parsable` to name a few.
 