### PR TITLE
chore: update `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,7 @@ insert_final_newline = true
 
 [{*.go,go.mod}]
 indent_style = tab
+indent_size = unset
 
 [*.{yaml,yml}]
 indent_size = 2
@@ -22,3 +23,4 @@ indent_size = 2
 
 [Makefile]
 indent_style = tab
+indent_size = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{go,mod}]
+[{*.go,go.mod}]
 indent_style = tab
 
 [Makefile]

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = unset
 [*.{yaml,yml}]
 indent_size = 2
 
+[*.md]
+indent_size = unset
+
 [*.nix]
 indent_size = 2
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,8 +11,14 @@ insert_final_newline = true
 [{*.go,go.mod}]
 indent_style = tab
 
+[*.nix]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[.ecrc]
+indent_size = 2
+
 [Makefile]
 indent_style = tab
-
-[*{.yml,.ecrc,.nix}]
-indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,10 +11,10 @@ insert_final_newline = true
 [{*.go,go.mod}]
 indent_style = tab
 
-[*.nix]
+[*.{yaml,yml}]
 indent_size = 2
 
-[*.yml]
+[*.nix]
 indent_size = 2
 
 [.ecrc]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,12 @@
 root = true
 
 [*]
-charset = utf-8
-insert_final_newline = true
-trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
 
 [*.{go,mod}]
 indent_style = tab


### PR DESCRIPTION
In #223, I said:

> Nested ordered lists must be indented by three spaces per level in the space indentation style

But having reviewed the GFM Spec carefully, I realized that was a misunderstanding. In the space indentation style, nested ordered lists must be indented by up to three spaces that left-align them with the contents of the parent list. In other words, the indentation of nested ordered lists depends on the width and indentation of the parent list marker. So this PR should fix the CI failure. Learn more: https://github.github.com/gfm/#motivation

Additionally, I made various nitpicking.