### PR TITLE
chore: Add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: github.com/editorconfig/editorconfig-core-go/v2
-    versions:
-    - 2.3.9
-    - 2.4.0
+  # ignore:
+  # - dependency-name: github.com/editorconfig/editorconfig-core-go/v2
+  #   versions:
+  #   - 2.3.9
+  #   - 2.4.0
+- package-ecosystem: "github-actions"
+  directory: "/" # == /.github/workflows/
+  schedule:
+    interval: "daily"


### PR DESCRIPTION
Also commented out
```yaml
  ignore:
  - dependency-name: github.com/editorconfig/editorconfig-core-go/v2
    versions:
    - 2.3.9
    - 2.4.0
```
as it was added by the dependabot [here](https://github.com/editorconfig-checker/editorconfig-checker/commit/e3bd197b185512066d63bc260724392b3c9eee79#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R8).