### PR TITLE
fix: adds dockerfile check dir to git safe dir list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN GO111MODULE=on CGO_ENABLED=0 go build -ldflags "-X main.version=$(cat VERSIO
 FROM alpine:latest
 
 RUN apk add --no-cache git
+RUN git config --global --add safe.directory /check
 WORKDIR /check/
 COPY --from=build /ec/bin/ec /usr/bin
 


### PR DESCRIPTION
I discovered this issue while "mocking" the [git command used to find files](https://github.com/editorconfig-checker/editorconfig-checker/blob/e2ce8ab5f3dd42a9b93a3ff2001ce007bea885c2/pkg/files/files.go#L98) in order to troubleshoot the difference between the container image published for 2.4.0 and 2.7.0. As it turns out, a newer version of git (bundled with the container image) [now errors on unsafe directories](https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory) causing `ec` to check all files in the directory (including those git ignored).

```
/check # git ls-files --cached --others --modified --exclude-standard
fatal: detected dubious ownership in repository at '/check'
To add an exception for this directory, call:

	git config --global --add safe.directory /check
```