### PR TITLE
ci: fix build docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,20 +46,16 @@ jobs:
         with:
           images: ${{ secrets.DOCKER_USERNAME }}/editorconfig-checker
 
-      - name: Build and push tagged Docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ secrets.DOCKER_USERNAME }}/editorconfig-checker:latest
           labels: ${{ steps.meta.outputs.labels }}
-          platform: linux/amd64,linux/arm64,linux/arm/v7
-
-      - name: Build and push latest Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: mstruebing/editorconfig-checker:latest
-          labels: ${{ steps.meta.outputs.labels }}
-          platform: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: |
+            linux/amd64
+            linux/arm64
+            linux/arm/v7


### PR DESCRIPTION
- fixed platform**s**
- removed one step with the build (added 2 tags in one build)

## Before:

![image](https://github.com/editorconfig-checker/editorconfig-checker/assets/1269939/72f7523f-2c0f-4dcd-b6d9-515478addf82)
```
$ time docker run --rm --volume=$(PWD):/check:delegated  mstruebing/editorconfig-checker
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested

________________________________________________________
Executed in    6.42 secs      fish           external
   usr time   40.33 millis    0.08 millis   40.25 millis
   sys time   23.14 millis    1.19 millis   21.95 millis
```

## After:

![image](https://github.com/editorconfig-checker/editorconfig-checker/assets/1269939/c37fbec6-dedd-4852-b95f-8c366b3332fa)
```
$ time docker run --rm --volume=$(PWD):/check:delegated  bondarslavik/editorconfig-checker

________________________________________________________
Executed in    3.82 secs      fish           external
   usr time   32.96 millis   78.00 micros   32.88 millis
   sys time   22.06 millis  832.00 micros   21.23 millis

```

Tested on MacBook M1Pro