### PR TITLE
docs: gitlab ci integration using ss-open/ci/recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,13 @@ ENABLE:
   - EDITORCONFIG
 ```
 
+### GitLab CI
+
+The [ss-open/ci/recipes project](https://gitlab.com/ss-open/ci/recipes) offers a ready to use lint job integrating editorconfig-checker.
+
+- Main documentation: https://gitlab.com/ss-open/ci/recipes/-/blob/main/README.md
+- Editorconfig job specific documentation: https://gitlab.com/ss-open/ci/recipes/-/blob/main/stages/lint/editorconfig/README.md
+
 ## Support
 
 If you have any questions, suggestions, need a wrapper for a programming language or just want to chat join #editorconfig-checker on freenode(IRC).


### PR DESCRIPTION
I recently found your editorconfig-checker project, a tool I was looking for from a while, thanks for that! :-) 

I did a fresh GitLab CI recipes open-source project. It include a large `lint` stage running different tools according to the changed file of a merge request.

I saw you have a space for the external integration of your tools so I took the liberty to add a space for GitLab CI trough my project. :-) 

I let you merge it if you agree for, also do not hesitate to adapt it to your needs! :+1: 

Thanks