### PR TITLE
feat: enable cached parser

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"strings"
 
+	"github.com/editorconfig/editorconfig-core-go/v2"
+
 	"github.com/editorconfig-checker/editorconfig-checker/pkg/logger"
 	"github.com/editorconfig-checker/editorconfig-checker/pkg/utils"
 )
@@ -90,7 +92,8 @@ type Config struct {
 	Disable             DisabledChecks
 
 	// MISC
-	Logger logger.Logger
+	Logger             logger.Logger
+	EditorconfigConfig *editorconfig.Config
 }
 
 // DisabledChecks is a Struct which represents disabled checks
@@ -111,6 +114,10 @@ func NewConfig(configPath string) (*Config, error) {
 	config.AllowedContentTypes = defaultAllowedContentTypes
 	config.Exclude = []string{}
 	config.PassedFiles = []string{}
+
+	config.EditorconfigConfig = &editorconfig.Config{
+		Parser: editorconfig.NewCachedParser(),
+	}
 
 	if !utils.IsRegularFile(configPath) {
 		return &config, fmt.Errorf("No file found at %s", configPath)
@@ -197,7 +204,8 @@ func (c *Config) Merge(config Config) {
 	c.Logger = logger.Logger{
 		Verbosee: c.Verbose || config.Verbose,
 		Debugg:   c.Debug || config.Debug,
-		NoColor:  c.NoColor || config.NoColor}
+		NoColor:  c.NoColor || config.NoColor,
+	}
 }
 
 // mergeDisabled merges the disabled checks into the config

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,11 +5,14 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
-const rootConfigFilePath = "../../.ecrc"
-const configWithIgnoredDefaults = "../../testfiles/.ecrc"
+const (
+	rootConfigFilePath        = "../../.ecrc"
+	configWithIgnoredDefaults = "../../testfiles/.ecrc"
+)
 
 func TestNewConfig(t *testing.T) {
 	actual, _ := NewConfig("abc")
@@ -111,6 +114,7 @@ func TestMerge(t *testing.T) {
 	expected.Logger.Verbosee = true
 	expected.Logger.Debugg = true
 	expected.Logger.NoColor = true
+	expected.EditorconfigConfig = c1.EditorconfigConfig
 
 	if !reflect.DeepEqual(c1, &expected) {
 		t.Errorf("%#v", &expected)
@@ -171,9 +175,9 @@ func TestGetAsString(t *testing.T) {
 	_ = c.Parse()
 
 	actual := c.GetAsString()
-	expected := "Config: {ShowVersion:false Help:false DryRun:false Path:../../.ecrc Version:2.7.2 Verbose:false Debug:false IgnoreDefaults:false SpacesAftertabs:false NoColor:false Exclude:[testfiles testdata] AllowedContentTypes:[text/ application/octet-stream application/ecmascript application/json application/x-ndjson application/xml +json +xml] PassedFiles:[] Disable:{EndOfLine:false Indentation:false InsertFinalNewline:false TrimTrailingWhitespace:false IndentSize:false MaxLineLength:false} Logger:{Verbosee:false Debugg:false NoColor:false}}"
+	expected := "Config: {ShowVersion:false Help:false DryRun:false Path:../../.ecrc Version:2.7.2 Verbose:false Debug:false IgnoreDefaults:false SpacesAftertabs:false NoColor:false Exclude:[testfiles testdata] AllowedContentTypes:[text/ application/octet-stream application/ecmascript application/json application/x-ndjson application/xml +json +xml] PassedFiles:[] Disable:{EndOfLine:false Indentation:false InsertFinalNewline:false TrimTrailingWhitespace:false IndentSize:false MaxLineLength:false} Logger:{Verbosee:false Debugg:false NoColor:false} EditorconfigConfig:0x"
 
-	if actual != expected {
+	if !strings.HasPrefix(actual, expected) {
 		t.Errorf("Expected: %v, got: %v ", expected, actual)
 	}
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestProcessValidation(t *testing.T) {
-	configuration := config.Config{Verbose: true}
+	configuration := config.Config{
+		Verbose: true,
+	}
 
 	processValidationResult := ProcessValidation([]string{"./../../cmd/editorconfig-checker/main.go"}, configuration)
 	if len(processValidationResult) > 1 || len(processValidationResult[0].Errors) != 0 {


### PR DESCRIPTION
Reading and parsing the ini file is done *once* per ini file rather than *the number of .editorconfig files* per file. So O(n) -> O(1) when it comes to reading the Editorconfig definition.

It doesn't seem to affect much the performance on the quick benchmark I did on saltstack/salt.