### PR TITLE
Use version appropriate Go module path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![ci](https://github.com/editorconfig-checker/editorconfig-checker/actions/workflows/ci.yml/badge.svg)](https://github.com/editorconfig-checker/editorconfig-checker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/editorconfig-checker/editorconfig-checker/branch/main/graph/badge.svg)](https://codecov.io/gh/editorconfig-checker/editorconfig-checker)
 [![Hits-of-Code](https://hitsofcode.com/github/editorconfig-checker/editorconfig-checker)](https://hitsofcode.com/view/github/editorconfig-checker/editorconfig-checker)
-[![Go Report Card](https://goreportcard.com/badge/github.com/editorconfig-checker/editorconfig-checker)](https://goreportcard.com/report/github.com/editorconfig-checker/editorconfig-checker)
+[![Go Report Card](https://goreportcard.com/badge/github.com/editorconfig-checker/editorconfig-checker/v2)](https://goreportcard.com/report/github.com/editorconfig-checker/editorconfig-checker/v2)
 
 ![Logo](docs/logo.png)
 
@@ -66,7 +66,7 @@ tar xzf ec-$OS-$ARCH.tar.gz && \
 
 Grab a binary from the [release page](https://github.com/editorconfig-checker/editorconfig-checker/releases).
 
-If you have go installed you can run `go get github.com/editorconfig-checker/editorconfig-checker` and run `make build` inside the project folder.
+If you have go installed you can run `go get github.com/editorconfig-checker/editorconfig-checker/v2` and run `make build` inside the project folder.
 This will place a binary called `ec` into the `bin` directory.
 
 If you are using Arch Linux, you can use [pacman](https://wiki.archlinux.org/title/Pacman) to install from [extra repository](https://archlinux.org/packages/extra/x86_64/editorconfig-checker/):
@@ -87,7 +87,7 @@ paru -S editorconfig-checker-git
 If go 1.16 or greater is installed, you can also install it globally via `go install`:
 
 ```shell
-go install github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest
+go install github.com/editorconfig-checker/editorconfig-checker/v2/cmd/editorconfig-checker@latest
 ```
 
 ## Usage

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/error"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/files"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/logger"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/utils"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/validation"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/error"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/validation"
 )
 
 // version is used vor the help

--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ buildGoPackage rec {
 
   name = "editorconfig-checker-${version}";
 
-  goPackagePath = "github.com/editorconfig-checker/editorconfig-checker";
+  goPackagePath = "github.com/editorconfig-checker/editorconfig-checker/v2";
 
   src = lib.cleanSourceWith {
     filter = name: type: builtins.match ".*tests.*" name == null;

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/editorconfig-checker/editorconfig-checker
+module github.com/editorconfig-checker/editorconfig-checker/v2
 
 go 1.21
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/editorconfig/editorconfig-core-go/v2"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/logger"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
 )
 
 // DefaultExcludes is the regular expression for ignored files

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -4,8 +4,8 @@ package error
 import (
 	"fmt"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/files"
 )
 
 // ValidationError represents one validation error

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
 )
 
 func TestGetErrorCount(t *testing.T) {

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/editorconfig/editorconfig-core-go/v2"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
 )
 
 const DefaultMimeType = "application/octet-stream"

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
 )
 
 func TestGetContentType(t *testing.T) {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/encoding"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/error"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/files"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/validation/validators"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/encoding"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/error"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/validation/validators"
 	"github.com/editorconfig/editorconfig-core-go/v2"
 )
 

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
 )
 
 func TestProcessValidation(t *testing.T) {

--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
 )
 
 // Indentation validates a files indentation

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
 )
 
 func TestFinalNewline(t *testing.T) {


### PR DESCRIPTION
There are two problems that cause **editorconfig-checker** to be difficult to use via the [Go module framework](https://go.dev/ref/mod):

- Non-compliant [module path](https://go.dev/ref/mod#module-path)
- Non-compliant [tag names](https://go.dev/ref/mod#versions)

The first of these problems is resolved here by adding the required `/v2` suffix to the Go module path, bringing it into compliance with the requirements of the Go module framework.

## Non-Compliant Module Path

A Go module is identified by a "[module path](https://go.dev/ref/mod#module-path)". The Go module framework requires that this path have a major version suffix if the project is at a version of 2.0.0 or above:

https://go.dev/ref/mod#major-version-suffixes

This project is at version 2.x, so its previous Go module path `github.com/editorconfig-checker/editorconfig-checker` violated this requirement.

## Non-Compliant Tag Names

The Go module framework requires that tag names use a "`v`" prefix (e.g., `v2.7.3`). The tag name format currently used by **editorconfig-checker** does not have this prefix (e.g., `2.7.2`). The Go module framework does not recognize these tags as release markers.

## Installation via `go install`

The non-compliances cause the command:

```text
go install github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest
```

to unexpectedly install a potentially unstable beta version of editorconfig-checker from the tip of the default branch.

Once the project is brought into compliance, the equivalent command:

```text
go install github.com/editorconfig-checker/editorconfig-checker/v2/cmd/editorconfig-checker@latest
```

will instead install the latest production release of the tool, which will be best practices for those using **editorconfig-checker** normally. It will still be possible for beta testers to install the development version of the tool by using `@main`, etc. as the ref in place of `@latest`.

## Use as Go Module Dependency

The Go module might be specified as a dependency of other projects for either of the following reasons:

- The project uses the module's packages in its own Go code
- The project uses **editorconfig-checker** as a tool dependency and wants to manage the versioning of that dependency using [a dummy "tools" Go package](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)

In either of these use cases, the project maintainer will typically have the following goals for managing the dependency:

- Pin the dependency at the latest stable release version on introduction
- Bump the dependency at each new stable release in a controlled manner

The non-compliances make both of these difficult:

By default, the Go module framework will pin the dependency at the unstable tip of the default branch if no compliant tags are found.

When there isn't a compliant tag to pin to, the Go module framework, a "[pseudo-version](https://go.dev/ref/mod#pseudo-versions)" (e.g., `v0.0.0-20231013082012-98f0d6560dba`) is used for the dependency's versioning. The popular [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) dependency management service will not offer updates for Go module dependencies using a pseudo-version, meaning the project maintainer must manage the dependency entirely manually.

## Documentation

The installation documentation has been updated to use the new module path.

## Backwards Compatibility

Due to the lack of any compliant tags in the repository, `go get` and `go install` commands using the old module path `github.com/editorconfig-checker/editorconfig-checker` that don't use an explicit ref in the [version query](https://go.dev/ref/mod#version-queries) will no longer work after the path change proposed here:

```text
$ go get github.com/editorconfig-checker/editorconfig-checker

go: github.com/editorconfig-checker/editorconfig-checker: no matching versions for query "upgrade"

$ go install github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest

go: github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@latest: no matching versions for query "latest"
```

Commands that use a commit hash ref (which includes projects that already have the dependency in their `go.mod`/`go.sum` files) will continue to work as before:

```text
$ go get github.com/editorconfig-checker/editorconfig-checker@98f0d6560dba

go: downloading github.com/editorconfig-checker/editorconfig-checker v0.0.0-20231013082012-98f0d6560dba
go: added github.com/editorconfig-checker/editorconfig-checker v0.0.0-20231013082012-98f0d6560dba

$ go install github.com/editorconfig-checker/editorconfig-checker/cmd/editorconfig-checker@98f0d6560dba

go: downloading github.com/editorconfig-checker/editorconfig-checker v0.0.0-20231013082012-98f0d6560dba
[...]
```

## Conclusion

The problem of non-compliant tag names must be fixed by an adjustment to the release procedure rather than a change to the repository contents. However, the change to a compliant module path name made here lays the groundwork for bringing the project into full compliance once compliant tag names are used for future releases.

Using a compliant module path as well as compliant tag names would benefit the users of editorconfig-checker by allowing them to install and manage it as a project dependency in a safe and efficient manner.