### PR TITLE
build: make sure the release tag has a leading v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ _checkout:
 
 _tag_version: current_version
 	@read -p "Enter version to release: " version && \
+	[[ $$version == v* ]]  && \ # check that there is leading v in the version
 	echo $${version} > VERSION && \
 	sed -i "s/VERSION=".*"/VERSION=\"$${version}\"/" ./README.md && \
 	sed -i "s/\"Version\": \".*\",/\"Version\": \"$${version}\",/" .ecrc && \

--- a/Makefile
+++ b/Makefile
@@ -161,10 +161,10 @@ _compress-all-binaries:
 _release_dockerfile: _build_dockerfile _push_dockerfile
 
 _build_dockerfile:
-	docker build -t mstruebing/editorconfig-checker:$(shell grep 'const version' cmd/editorconfig-checker/main.go | sed 's/.*"\(.*\)"/\1/') .
+	docker buildx build -t mstruebing/editorconfig-checker:$(shell cat VERSION) .
 
 _push_dockerfile:
-	docker push mstruebing/editorconfig-checker:$(shell grep 'const version' cmd/editorconfig-checker/main.go | sed 's/.*"\(.*\)"/\1/')
+	docker push mstruebing/editorconfig-checker:$(shell cat VERSION)
 
 nix-build: ## Build for nix
 	nix-build -E 'with import <nixpkgs> { }; callPackage ./default.nix {}'

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ _checkout:
 
 _tag_version: current_version
 	@read -p "Enter version to release: " version && \
-	[[ $$version == v* ]]  && \ # check that there is leading v in the version
+	[[ $$version == v* ]]  && \
 	echo $${version} > VERSION && \
 	sed -i "s/VERSION=".*"/VERSION=\"$${version}\"/" ./README.md && \
 	sed -i "s/\"Version\": \".*\",/\"Version\": \"$${version}\",/" .ecrc && \


### PR DESCRIPTION
This PR makes sure that the released tag has a leading `v` which is important after #307 was merged.

The easiest way to test this locally is to add an `exit 1` in line 81 in the `Makefile` right before the push: https://github.com/editorconfig-checker/editorconfig-checker/blob/main/Makefile#L81

@per1234 could you run this locally with the mentioned change?

You need to run `make release` and it is asking you for a version, just put `v2.7.8` for example.
I was able to run `make build` and `make test` after this and the release succeeded as well.
Could you have a look over the changes which are made locally so that everything is changed as expected?

I just want to be sure that it is working before releasing a new version.

Edit:
I remembered that you need to be on the `main` branch for this. So you might want to merge this locally or just skip this check when you test it locally.