### PR TITLE
feat: add output format option with 'gcc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ USAGE:
         show which files would be checked
   -exclude string
         a regex which files should be excluded from checking - needs to be a valid regular expression
+  -format
+        specifies the output format, see "Formats" below for more information
   -h    print the help
   -help
         print the help
@@ -131,6 +133,14 @@ USAGE:
 If you run this tool from a repository root it will check all files which are added to the git repository and are text files. If the tool isn't able to determine a file type it will be added to be checked too.
 
 If you run this tool from a normal directory it will check all files which are text files. If the tool isn't able to determine a file type it will be added to be checked too.
+
+### Formats
+
+The following output formats are supported:
+
+- **default**: Plain text, human readable output.
+- **gcc**: GCC compatible output. Useful for editors that support compiling and showing syntax errors.
+           <file>:<line>:<column>: <type>: <message>
 
 ## Configuration
 

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -39,6 +39,8 @@ func init() {
 	flag.BoolVar(&c.ShowVersion, "version", false, "print the version number")
 	flag.BoolVar(&c.Help, "help", false, "print the help")
 	flag.BoolVar(&c.Help, "h", false, "print the help")
+	flag.StringVar(&c.Format, "format", "default", "specify the output format: default, gcc")
+	flag.StringVar(&c.Format, "f", "default", "specify the output format: default, gcc")
 	flag.BoolVar(&c.Verbose, "verbose", false, "print debugging information")
 	flag.BoolVar(&c.Verbose, "v", false, "print debugging information")
 	flag.BoolVar(&c.Debug, "debug", false, "print debugging information")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -82,6 +82,7 @@ type Config struct {
 	// CONFIG FILE
 	Version             string
 	Verbose             bool
+	Format              string
 	Debug               bool
 	IgnoreDefaults      bool
 	SpacesAftertabs     bool
@@ -166,6 +167,10 @@ func (c *Config) Merge(config Config) {
 
 	if config.Verbose {
 		c.Verbose = config.Verbose
+	}
+
+	if config.Format != "" {
+		c.Format = config.Format
 	}
 
 	if config.Debug {
@@ -254,6 +259,7 @@ func (c Config) Save(version string) error {
 	type writtenConfig struct {
 		Version             string
 		Verbose             bool
+		Format              string
 		Debug               bool
 		IgnoreDefaults      bool
 		SpacesAftertabs     bool

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -88,6 +88,7 @@ func TestMerge(t *testing.T) {
 		DryRun:              true,
 		Path:                "some-other",
 		Verbose:             true,
+		Format:              "default",
 		Debug:               true,
 		NoColor:             true,
 		IgnoreDefaults:      true,
@@ -175,7 +176,7 @@ func TestGetAsString(t *testing.T) {
 	_ = c.Parse()
 
 	actual := c.GetAsString()
-	expected := "Config: {ShowVersion:false Help:false DryRun:false Path:../../.ecrc Version:2.7.2 Verbose:false Debug:false IgnoreDefaults:false SpacesAftertabs:false NoColor:false Exclude:[testfiles testdata] AllowedContentTypes:[text/ application/octet-stream application/ecmascript application/json application/x-ndjson application/xml +json +xml] PassedFiles:[] Disable:{EndOfLine:false Indentation:false InsertFinalNewline:false TrimTrailingWhitespace:false IndentSize:false MaxLineLength:false} Logger:{Verbosee:false Debugg:false NoColor:false} EditorconfigConfig:0x"
+	expected := "Config: {ShowVersion:false Help:false DryRun:false Path:../../.ecrc Version:2.7.2 Verbose:false Format: Debug:false IgnoreDefaults:false SpacesAftertabs:false NoColor:false Exclude:[testfiles testdata] AllowedContentTypes:[text/ application/octet-stream application/ecmascript application/json application/x-ndjson application/xml +json +xml] PassedFiles:[] Disable:{EndOfLine:false Indentation:false InsertFinalNewline:false TrimTrailingWhitespace:false IndentSize:false MaxLineLength:false} Logger:{Verbosee:false Debugg:false NoColor:false} EditorconfigConfig:0x"
 
 	if !strings.HasPrefix(actual, expected) {
 		t.Errorf("Expected: %v, got: %v ", expected, actual)

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -42,14 +42,25 @@ func PrintErrors(errors []ValidationErrors, config config.Config) {
 				continue
 			}
 
-			config.Logger.Warning(fmt.Sprintf("%s:", relativeFilePath))
-			for _, singleError := range fileErrors.Errors {
-				if singleError.LineNumber != -1 {
-					config.Logger.Error(fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message))
-				} else {
-					config.Logger.Error(fmt.Sprintf("\t%s", singleError.Message))
+			if config.Format == "gcc" {
+				// gcc: A format mimicking the error format from GCC.
+				for _, singleError := range fileErrors.Errors {
+					var lineNo = 0
+					if singleError.LineNumber > 0 {
+						lineNo = singleError.LineNumber
+					}
+					config.Logger.Error(fmt.Sprintf("%s:%d:%d: %s: %s", relativeFilePath, lineNo, 0, "error", singleError.Message))
 				}
-
+			} else {
+				// default: A human readable text format.
+				config.Logger.Warning(fmt.Sprintf("%s:", relativeFilePath))
+				for _, singleError := range fileErrors.Errors {
+					if singleError.LineNumber != -1 {
+						config.Logger.Error(fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message))
+					} else {
+						config.Logger.Error(fmt.Sprintf("\t%s", singleError.Message))
+					}
+				}
 			}
 		}
 	}

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -152,6 +152,9 @@ func TestPrintErrors(t *testing.T) {
 	}
 
 	// wannabe test
-	config := config.Config{}
-	PrintErrors(input, config)
+	config1 := config.Config{}
+	PrintErrors(input, config1)
+
+	config2 := config.Config{Format: "gcc"}
+	PrintErrors(input, config2)
 }

--- a/testfiles/generated-config.json
+++ b/testfiles/generated-config.json
@@ -1,6 +1,7 @@
 {
   "Version": "2.7.2",
   "Verbose": false,
+  "Format": "",
   "Debug": false,
   "IgnoreDefaults": false,
   "SpacesAftertabs": false,


### PR DESCRIPTION
Relating to #145, a new command-line option  was added. The current output format is named 'default', and a new format 'gcc' was added that uses an error format similar
to gcc, namely:  `<file>:<lineNo>:<charNo>: <type/severity>: <message>`

This command-line option mirrors that used by the common linting tool shellcheck: https://www.mankier.com/1/shellcheck

Example output:
```
$ ./bin/ec --format=gcc ~/files/dummy.*
../../files/dummy.bat:0:0: error: Wrong line endings or no final newline
../../files/dummy.bat:0:0: error: Not all lines have the correct end of line character
../../files/dummy.d:2:0: error: Line too long (113 instead of 100)
../../files/dummy.d:3:0: error: Wrong amount of left-padding spaces(want multiple of 2)
```