### PR TITLE
fix: call with sub directory

### DIFF
--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -75,7 +75,7 @@ func AddToFiles(filePaths []string, filePath string, config config.Config) []str
 
 // GetFiles returns all files which should be checked
 func GetFiles(config config.Config) ([]string, error) {
-	var filePaths []string
+	filePaths := make([]string, 0)
 
 	// Handle explicit passed files
 	if len(config.PassedFiles) != 0 {
@@ -92,7 +92,7 @@ func GetFiles(config config.Config) ([]string, error) {
 					}
 
 					if fi.Mode().IsRegular() {
-						filePaths = AddToFiles(filePaths, path, config)
+						filePaths = AddToFiles(filePaths, filepath.Join(passedFile, path), config)
 					}
 
 					return nil

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -151,14 +151,18 @@ func TestAddToFiles(t *testing.T) {
 		config    config.Config
 		expected  []string
 	}{
-		{[]string{},
+		{
+			[]string{},
 			"./files.go",
 			excludedFileConfiguration,
-			[]string{}},
-		{[]string{"./files.go"},
+			[]string{},
+		},
+		{
+			[]string{"./files.go"},
 			"./files.go",
 			configuration,
-			[]string{"./files.go"}},
+			[]string{"./files.go"},
+		},
 	}
 
 	for _, tt := range addToFilesTests {
@@ -173,18 +177,27 @@ func TestAddToFiles(t *testing.T) {
 }
 
 func TestGetFiles(t *testing.T) {
-	configuration := config.Config{}
-	_, err := GetFiles(configuration)
-
-	if err != nil {
-		t.Errorf("GetFiles(): expected nil, got %s", err.Error())
+	configurations := []config.Config{
+		{},
+		{
+			PassedFiles: []string{"./../../docs/"},
+		},
 	}
 
-	configuration.PassedFiles = []string{"."}
-	files, err := GetFiles(configuration)
+	for _, configuration := range configurations {
+		configuration := configuration
 
-	if len(files) > 0 && err != nil {
-		t.Errorf("GetFiles(.): expected nil, got %s", err.Error())
+		_, err := GetFiles(configuration)
+		if err != nil {
+			t.Errorf("GetFiles(): expected nil, got %s", err.Error())
+		}
+
+		configuration.PassedFiles = []string{"."}
+		files, err := GetFiles(configuration)
+
+		if len(files) > 0 && err != nil {
+			t.Errorf("GetFiles(.): expected nil, got %s", err.Error())
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #326

```console
go run github.com/editorconfig-checker/editorconfig-checker/v2/cmd/editorconfig-checker@a7a8d55e3aaecd1b5f1d4c98df01bc12ccf857b7
```