### PR TITLE
fix: v3 prefix is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![ci](https://github.com/editorconfig-checker/editorconfig-checker/actions/workflows/ci.yml/badge.svg)](https://github.com/editorconfig-checker/editorconfig-checker/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/editorconfig-checker/editorconfig-checker/branch/main/graph/badge.svg)](https://codecov.io/gh/editorconfig-checker/editorconfig-checker)
 [![Hits-of-Code](https://hitsofcode.com/github/editorconfig-checker/editorconfig-checker)](https://hitsofcode.com/view/github/editorconfig-checker/editorconfig-checker)
-[![Go Report Card](https://goreportcard.com/badge/github.com/editorconfig-checker/editorconfig-checker/v2)](https://goreportcard.com/report/github.com/editorconfig-checker/editorconfig-checker/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/editorconfig-checker/editorconfig-checker/v3)](https://goreportcard.com/report/github.com/editorconfig-checker/editorconfig-checker/v3)
 
 ![Logo](docs/logo.png)
 
@@ -66,7 +66,7 @@ tar xzf ec-$OS-$ARCH.tar.gz && \
 
 Grab a binary from the [release page](https://github.com/editorconfig-checker/editorconfig-checker/releases).
 
-If you have go installed you can run `go get github.com/editorconfig-checker/editorconfig-checker/v2` and run `make build` inside the project folder.
+If you have go installed you can run `go get github.com/editorconfig-checker/editorconfig-checker/v3` and run `make build` inside the project folder.
 This will place a binary called `ec` into the `bin` directory.
 
 If you are using Arch Linux, you can use [pacman](https://wiki.archlinux.org/title/Pacman) to install from [extra repository](https://archlinux.org/packages/extra/x86_64/editorconfig-checker/):
@@ -87,7 +87,7 @@ paru -S editorconfig-checker-git
 If go 1.16 or greater is installed, you can also install it globally via `go install`:
 
 ```shell
-go install github.com/editorconfig-checker/editorconfig-checker/v2/cmd/editorconfig-checker@latest
+go install github.com/editorconfig-checker/editorconfig-checker/v3/cmd/editorconfig-checker@latest
 ```
 
 ## Usage

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/error"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/files"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/logger"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/validation"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/error"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/validation"
 )
 
 // version is used vor the help

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/editorconfig-checker/editorconfig-checker/v2
+module github.com/editorconfig-checker/editorconfig-checker/v3
 
 go 1.21
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/editorconfig/editorconfig-core-go/v2"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/logger"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
 )
 
 // DefaultExcludes is the regular expression for ignored files

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -4,8 +4,8 @@ package error
 import (
 	"fmt"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
 )
 
 // ValidationError represents one validation error

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 )
 
 func TestGetErrorCount(t *testing.T) {

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/editorconfig/editorconfig-core-go/v2"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
 )
 
 const DefaultMimeType = "application/octet-stream"

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 )
 
 func TestGetContentType(t *testing.T) {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/encoding"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/error"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/files"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/validation/validators"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/encoding"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/error"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/validation/validators"
 	"github.com/editorconfig/editorconfig-core-go/v2"
 )
 

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -3,7 +3,7 @@ package validation
 import (
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 )
 
 func TestProcessValidation(t *testing.T) {

--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/utils"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
 )
 
 // Indentation validates a files indentation

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/editorconfig-checker/editorconfig-checker/v2/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 )
 
 func TestFinalNewline(t *testing.T) {


### PR DESCRIPTION
Since that package is now a v3, it needs to be reflected in the `go.mod` file.

Closes #338