### PR TITLE
ci: run docker login and publish on main and on tags creation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' || github.ref.type == 'tag' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -49,7 +49,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.ref_name == 'main' || github.ref.type == 'tag' }}
           tags: |
             ${{ steps.meta.outputs.tags }}
             ${{ secrets.DOCKER_USERNAME || 'dev' }}/editorconfig-checker:latest


### PR DESCRIPTION
This PR should push a new docker image whenever we are on the main branch or we create a new tag


* Closes #342
