### PR TITLE
feat: add zip version when compressing all binaries (#321)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,7 @@ _build-all-binaries:
 _compress-all-binaries:
 	for f in bin/*; do      \
 		tar czf $$f.tar.gz $$f;    \
+		zip $$f.zip $$f;    \
 		rm -f $$f;    \
 	done
 


### PR DESCRIPTION
This adds a zip archive to the output of the compress-all-binaries sub-task in order to provide better compatiblitiy with Windows.

Windows does not come with the ability to handle tar.gz (until now the only output format) and, hence, users cannot easily use the prebuilt binaries distributed via GitHub. Further integration into, for example, the winget community packages is also prevented by this.

Zip was chosen as an _additional_ output format in order to not create an unexpected/breaking change for consumers of the existing tar.gz format.

Windows is not handled specifically here in order to keep the process of providing build artifacts as simple as possible.