### PR TITLE
Provide Codeclimate compatible report fromat

### DIFF
--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -39,8 +39,8 @@ func init() {
 	flag.BoolVar(&c.ShowVersion, "version", false, "print the version number")
 	flag.BoolVar(&c.Help, "help", false, "print the help")
 	flag.BoolVar(&c.Help, "h", false, "print the help")
-	flag.StringVar(&c.Format, "format", "default", "specify the output format: default, gcc")
-	flag.StringVar(&c.Format, "f", "default", "specify the output format: default, gcc")
+	flag.StringVar(&c.Format, "format", "default", "specify the output format: default, gcc, codeclimate")
+	flag.StringVar(&c.Format, "f", "default", "specify the output format: default, gcc, codeclimate")
 	flag.BoolVar(&c.Verbose, "verbose", false, "print debugging information")
 	flag.BoolVar(&c.Verbose, "v", false, "print debugging information")
 	flag.BoolVar(&c.Debug, "debug", false, "print debugging information")
@@ -126,7 +126,9 @@ func main() {
 
 	if errorCount != 0 {
 		error.PrintErrors(errors, config)
-		config.Logger.Error(fmt.Sprintf("\n%d errors found", errorCount))
+		if config.Format == "default" {
+			config.Logger.Error(fmt.Sprintf("\n%d errors found", errorCount))
+		}
 	}
 
 	config.Logger.Verbose("%d files checked", len(filePaths))

--- a/pkg/error/format_codeclimate.go
+++ b/pkg/error/format_codeclimate.go
@@ -1,0 +1,50 @@
+package error
+
+import (
+	"crypto/md5"
+	"fmt"
+	"strconv"
+)
+
+// CodeclimageLines represents the lines of an issue in codeclimate format
+type CodeclimateLines struct {
+	Begin int `json:"begin"`
+	End   int `json:"end"`
+}
+
+// CodeclimateLocation represents the location of an issue in codeclimate format
+type CodeclimateLocation struct {
+	Path  string           `json:"path"`
+	Lines CodeclimateLines `json:"lines"`
+}
+
+// CodeclimateIssue represents an issue in codeclimate format
+type CodeclimateIssue struct {
+	Check       string              `json:"check_name"`
+	Description string              `json:"description"`
+	Fingerprint string              `json:"fingerprint"`
+	Severity    string              `json:"severity"`
+	Location    CodeclimateLocation `json:"location"`
+}
+
+const (
+	checkName = "editorconfig-checker"
+	severity  = "minor"
+)
+
+func newCodeclimateIssue(err ValidationError, path string) CodeclimateIssue {
+	fingerprint := fmt.Sprintf("%x", md5.Sum([]byte(path+strconv.Itoa(err.LineNumber)+err.Message.Error())))
+	return CodeclimateIssue{
+		Check:       checkName,
+		Description: err.Message.Error(),
+		Fingerprint: fingerprint,
+		Severity:    severity,
+		Location: CodeclimateLocation{
+			Path: path,
+			Lines: CodeclimateLines{
+				Begin: err.LineNumber,
+				End:   err.LineNumber, // Currently we only have one line per issue
+			},
+		},
+	}
+}


### PR DESCRIPTION
Provide code quality report as JSON according to Code Climate specificiation. This is need when using the editorconfig-checker in GitLab CI.

More details: #365