### PR TITLE
refactor: output FormatErrors

### DIFF
--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/error"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/outputformat"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/validation"
 )
@@ -39,8 +40,8 @@ func init() {
 	flag.BoolVar(&c.ShowVersion, "version", false, "print the version number")
 	flag.BoolVar(&c.Help, "help", false, "print the help")
 	flag.BoolVar(&c.Help, "h", false, "print the help")
-	flag.StringVar(&c.Format, "format", "default", "specify the output format: default, gcc, github-actions, codeclimate")
-	flag.StringVar(&c.Format, "f", "default", "specify the output format: default, gcc, github-actions, codeclimate")
+	flag.TextVar(&c.Format, "format", outputformat.Default, "specify the output format: "+outputformat.GetArgumentChoiceText())
+	flag.TextVar(&c.Format, "f", outputformat.Default, "specify the output format: "+outputformat.GetArgumentChoiceText())
 	flag.BoolVar(&c.Verbose, "verbose", false, "print debugging information")
 	flag.BoolVar(&c.Verbose, "v", false, "print debugging information")
 	flag.BoolVar(&c.Debug, "debug", false, "print debugging information")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"github.com/editorconfig/editorconfig-core-go/v2"
 
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/outputformat"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
 )
 
@@ -86,7 +87,7 @@ type Config struct {
 	// CONFIG FILE
 	Version             string
 	Verbose             bool
-	Format              string
+	Format              outputformat.OutputFormat
 	Debug               bool
 	IgnoreDefaults      bool
 	SpacesAftertabs     bool
@@ -186,7 +187,7 @@ func (c *Config) Merge(config Config) {
 		c.Verbose = config.Verbose
 	}
 
-	if config.Format != "" {
+	if config.Format.IsValid() {
 		c.Format = config.Format
 	}
 

--- a/pkg/error/__snapshots__/pathseparator-backslash/error_test.snap
+++ b/pkg/error/__snapshots__/pathseparator-backslash/error_test.snap
@@ -1,5 +1,11 @@
 
-[TestFormatErrors - 1]
+[TestFormatErrors/codeclimate - 1]
+[]logger.LogMessage{
+    {Level:"", Message:"[{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"f9f3ebd33d41709a172ea4170461ad08\",\"severity\":\"minor\",\"location\":{\"path\":\"/proc/cpuinfo\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"8813fafd9666527940189f0eb71017cf\",\"severity\":\"minor\",\"location\":{\"path\":\"/proc/cpuinfoNOT\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"3d1d5dbbb6516a1ff6dfd7d463e39c92\",\"severity\":\"minor\",\"location\":{\"path\":\"some/other/path\",\"lines\":{\"begin\":-1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"5047d0cb8e7ab136ef2c8409c7ef3ac3\",\"severity\":\"minor\",\"location\":{\"path\":\"some/other/path\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"file-level error\",\"fingerprint\":\"d4c61b75e2e08b3f2eb497e4bbe563d1\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":-1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"57fe25411e900e3f07da07aeea8c0f64\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":1,\"end\":1}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"797f0cfb797675c4bed477a1067e8ef4\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":4,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind two\",\"fingerprint\":\"72013244ffd1c1406ad764b9de9ce525\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":5,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"0e3f77d4a6f1ffbcc7b8b8a971679f46\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":6,\"end\":0}}}]"},
+}
+---
+
+[TestFormatErrors/default - 1]
 []logger.LogMessage{
     {Level:"warning", Message:"/proc/cpuinfo:"},
     {Level:"error", Message:"\t1: WRONG"},
@@ -17,7 +23,7 @@
 }
 ---
 
-[TestFormatErrors - 2]
+[TestFormatErrors/gcc - 1]
 []logger.LogMessage{
     {Level:"error", Message:"/proc/cpuinfo:1:0: error: WRONG"},
     {Level:"error", Message:"/proc/cpuinfoNOT:1:0: error: WRONG"},
@@ -32,7 +38,7 @@
 }
 ---
 
-[TestFormatErrors - 3]
+[TestFormatErrors/github-actions - 1]
 []logger.LogMessage{
     {Level:"error", Message:"::error file=/proc/cpuinfo,line=1::WRONG"},
     {Level:"error", Message:"::error file=/proc/cpuinfoNOT,line=1::WRONG"},

--- a/pkg/error/__snapshots__/pathseparator-slash/error_test.snap
+++ b/pkg/error/__snapshots__/pathseparator-slash/error_test.snap
@@ -1,5 +1,11 @@
 
-[TestFormatErrors - 1]
+[TestFormatErrors/codeclimate - 1]
+[]logger.LogMessage{
+    {Level:"", Message:"[{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"bcd0ed212d202770869048ac50ceea7c\",\"severity\":\"minor\",\"location\":{\"path\":\"proc/cpuinfo\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"8508b1c217914f89d2fbbd0b14eef007\",\"severity\":\"minor\",\"location\":{\"path\":\"proc/cpuinfoNOT\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"3d1d5dbbb6516a1ff6dfd7d463e39c92\",\"severity\":\"minor\",\"location\":{\"path\":\"some/other/path\",\"lines\":{\"begin\":-1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"5047d0cb8e7ab136ef2c8409c7ef3ac3\",\"severity\":\"minor\",\"location\":{\"path\":\"some/other/path\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"file-level error\",\"fingerprint\":\"d4c61b75e2e08b3f2eb497e4bbe563d1\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":-1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"57fe25411e900e3f07da07aeea8c0f64\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":1,\"end\":1}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"797f0cfb797675c4bed477a1067e8ef4\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":4,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind two\",\"fingerprint\":\"72013244ffd1c1406ad764b9de9ce525\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":5,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"0e3f77d4a6f1ffbcc7b8b8a971679f46\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":6,\"end\":0}}}]"},
+}
+---
+
+[TestFormatErrors/default - 1]
 []logger.LogMessage{
     {Level:"warning", Message:"proc/cpuinfo:"},
     {Level:"error", Message:"\t1: WRONG"},
@@ -17,7 +23,7 @@
 }
 ---
 
-[TestFormatErrors - 2]
+[TestFormatErrors/gcc - 1]
 []logger.LogMessage{
     {Level:"error", Message:"proc/cpuinfo:1:0: error: WRONG"},
     {Level:"error", Message:"proc/cpuinfoNOT:1:0: error: WRONG"},
@@ -32,7 +38,7 @@
 }
 ---
 
-[TestFormatErrors - 3]
+[TestFormatErrors/github-actions - 1]
 []logger.LogMessage{
     {Level:"error", Message:"::error file=proc/cpuinfo,line=1::WRONG"},
     {Level:"error", Message:"::error file=proc/cpuinfoNOT,line=1::WRONG"},
@@ -43,11 +49,5 @@
     {Level:"error", Message:"::error file=some/file/with/consecutive/errors,line=4::message kind one"},
     {Level:"error", Message:"::error file=some/file/with/consecutive/errors,line=5::message kind two"},
     {Level:"error", Message:"::error file=some/file/with/consecutive/errors,line=6::message kind one"},
-}
----
-
-[TestFormatErrors - 4]
-[]logger.LogMessage{
-    {Level:"", Message:"[{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"bcd0ed212d202770869048ac50ceea7c\",\"severity\":\"minor\",\"location\":{\"path\":\"proc/cpuinfo\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"8508b1c217914f89d2fbbd0b14eef007\",\"severity\":\"minor\",\"location\":{\"path\":\"proc/cpuinfoNOT\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"3d1d5dbbb6516a1ff6dfd7d463e39c92\",\"severity\":\"minor\",\"location\":{\"path\":\"some/other/path\",\"lines\":{\"begin\":-1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"WRONG\",\"fingerprint\":\"5047d0cb8e7ab136ef2c8409c7ef3ac3\",\"severity\":\"minor\",\"location\":{\"path\":\"some/other/path\",\"lines\":{\"begin\":1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"file-level error\",\"fingerprint\":\"d4c61b75e2e08b3f2eb497e4bbe563d1\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":-1,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"57fe25411e900e3f07da07aeea8c0f64\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":1,\"end\":1}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"797f0cfb797675c4bed477a1067e8ef4\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":4,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind two\",\"fingerprint\":\"72013244ffd1c1406ad764b9de9ce525\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":5,\"end\":0}}},{\"check_name\":\"editorconfig-checker\",\"description\":\"message kind one\",\"fingerprint\":\"0e3f77d4a6f1ffbcc7b8b8a971679f46\",\"severity\":\"minor\",\"location\":{\"path\":\"some/file/with/consecutive/errors\",\"lines\":{\"begin\":6,\"end\":0}}}]"},
 }
 ---

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -88,7 +88,7 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 }
 
 func FormatErrorsAsHumanReadable(errors []ValidationErrors, config config.Config) []logger.LogMessage {
-	var formatted_errors []logger.LogMessage
+	var logMessages []logger.LogMessage
 
 	for _, fileErrors := range errors {
 		if len(fileErrors.Errors) == 0 {
@@ -97,33 +97,33 @@ func FormatErrorsAsHumanReadable(errors []ValidationErrors, config config.Config
 
 		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
 		if err != nil {
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
+			logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: err.Error()})
 			continue
 		}
 
 		fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
 
-		formatted_errors = append(formatted_errors, logger.LogMessage{Level: "warning", Message: fmt.Sprintf("%s:", relativeFilePath)})
+		logMessages = append(logMessages, logger.LogMessage{Level: "warning", Message: fmt.Sprintf("%s:", relativeFilePath)})
 		for _, singleError := range fileErrors.Errors {
 			if singleError.LineNumber == -1 {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%s", singleError.Message)})
+				logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%s", singleError.Message)})
 				continue
 			}
 
 			if singleError.AdditionalIdenticalErrorCount == 0 {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message)})
+				logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message)})
 				continue
 			}
 
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d-%d: %s", singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
+			logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d-%d: %s", singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
 		}
 	}
 
-	return formatted_errors
+	return logMessages
 }
 
 func FormatErrorsAsGHA(errors []ValidationErrors, config config.Config) []logger.LogMessage {
-	var formatted_errors []logger.LogMessage
+	var logMessages []logger.LogMessage
 
 	for _, fileErrors := range errors {
 		if len(fileErrors.Errors) == 0 {
@@ -132,7 +132,7 @@ func FormatErrorsAsGHA(errors []ValidationErrors, config config.Config) []logger
 
 		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
 		if err != nil {
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
+			logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: err.Error()})
 			continue
 		}
 
@@ -141,25 +141,25 @@ func FormatErrorsAsGHA(errors []ValidationErrors, config config.Config) []logger
 		// github-actions: A format dedicated for usage in Github Actions
 		for _, singleError := range fileErrors.Errors {
 			if singleError.LineNumber == -1 {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s::%s", relativeFilePath, singleError.Message)})
+				logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s::%s", relativeFilePath, singleError.Message)})
 				continue
 			}
 
 			if singleError.AdditionalIdenticalErrorCount == 0 {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d::%s", relativeFilePath, singleError.LineNumber, singleError.Message)})
+				logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d::%s", relativeFilePath, singleError.LineNumber, singleError.Message)})
 				continue
 			}
 
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d,endLine=%d::%s", relativeFilePath, singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
+			logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d,endLine=%d::%s", relativeFilePath, singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
 		}
 	}
 
-	return formatted_errors
+	return logMessages
 }
 
 // gcc: A format mimicking the error format from GCC.
 func FormatErrorsAsGCC(errors []ValidationErrors, config config.Config) []logger.LogMessage {
-	var formatted_errors []logger.LogMessage
+	var logMessages []logger.LogMessage
 
 	for _, fileErrors := range errors {
 		if len(fileErrors.Errors) == 0 {
@@ -168,7 +168,7 @@ func FormatErrorsAsGCC(errors []ValidationErrors, config config.Config) []logger
 
 		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
 		if err != nil {
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
+			logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: err.Error()})
 			continue
 		}
 
@@ -177,11 +177,11 @@ func FormatErrorsAsGCC(errors []ValidationErrors, config config.Config) []logger
 			if singleError.LineNumber > 0 {
 				lineNo = singleError.LineNumber
 			}
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("%s:%d:%d: %s: %s", relativeFilePath, lineNo, 0, "error", singleError.Message)})
+			logMessages = append(logMessages, logger.LogMessage{Level: "error", Message: fmt.Sprintf("%s:%d:%d: %s: %s", relativeFilePath, lineNo, 0, "error", singleError.Message)})
 		}
 	}
 
-	return formatted_errors
+	return logMessages
 }
 
 // codeclimate: A format that is compatible with the codeclimate format for GitLab CI.

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -91,26 +91,28 @@ func FormatErrorsAsHumanReadable(errors []ValidationErrors, config config.Config
 	var formatted_errors []logger.LogMessage
 
 	for _, fileErrors := range errors {
-		if len(fileErrors.Errors) > 0 {
-			relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
-			if err != nil {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
-				continue
-			}
+		if len(fileErrors.Errors) == 0 {
+			continue
+		}
 
-			fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
+		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
+		if err != nil {
+			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
+			continue
+		}
 
-			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "warning", Message: fmt.Sprintf("%s:", relativeFilePath)})
-			for _, singleError := range fileErrors.Errors {
-				if singleError.LineNumber != -1 {
-					if singleError.AdditionalIdenticalErrorCount != 0 {
-						formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d-%d: %s", singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
-					} else {
-						formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message)})
-					}
+		fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
+
+		formatted_errors = append(formatted_errors, logger.LogMessage{Level: "warning", Message: fmt.Sprintf("%s:", relativeFilePath)})
+		for _, singleError := range fileErrors.Errors {
+			if singleError.LineNumber != -1 {
+				if singleError.AdditionalIdenticalErrorCount != 0 {
+					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d-%d: %s", singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
 				} else {
-					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%s", singleError.Message)})
+					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message)})
 				}
+			} else {
+				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%s", singleError.Message)})
 			}
 		}
 	}
@@ -122,26 +124,28 @@ func FormatErrorsAsGHA(errors []ValidationErrors, config config.Config) []logger
 	var formatted_errors []logger.LogMessage
 
 	for _, fileErrors := range errors {
-		if len(fileErrors.Errors) > 0 {
-			relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
-			if err != nil {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
-				continue
-			}
+		if len(fileErrors.Errors) == 0 {
+			continue
+		}
 
-			fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
+		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
+		if err != nil {
+			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
+			continue
+		}
 
-			// github-actions: A format dedicated for usage in Github Actions
-			for _, singleError := range fileErrors.Errors {
-				if singleError.LineNumber != -1 {
-					if singleError.AdditionalIdenticalErrorCount != 0 {
-						formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d,endLine=%d::%s", relativeFilePath, singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
-					} else {
-						formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d::%s", relativeFilePath, singleError.LineNumber, singleError.Message)})
-					}
+		fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
+
+		// github-actions: A format dedicated for usage in Github Actions
+		for _, singleError := range fileErrors.Errors {
+			if singleError.LineNumber != -1 {
+				if singleError.AdditionalIdenticalErrorCount != 0 {
+					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d,endLine=%d::%s", relativeFilePath, singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
 				} else {
-					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s::%s", relativeFilePath, singleError.Message)})
+					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d::%s", relativeFilePath, singleError.LineNumber, singleError.Message)})
 				}
+			} else {
+				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s::%s", relativeFilePath, singleError.Message)})
 			}
 		}
 	}
@@ -154,20 +158,22 @@ func FormatErrorsAsGCC(errors []ValidationErrors, config config.Config) []logger
 	var formatted_errors []logger.LogMessage
 
 	for _, fileErrors := range errors {
-		if len(fileErrors.Errors) > 0 {
-			relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
-			if err != nil {
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
-				continue
-			}
+		if len(fileErrors.Errors) == 0 {
+			continue
+		}
 
-			for _, singleError := range fileErrors.Errors {
-				var lineNo = 0
-				if singleError.LineNumber > 0 {
-					lineNo = singleError.LineNumber
-				}
-				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("%s:%d:%d: %s: %s", relativeFilePath, lineNo, 0, "error", singleError.Message)})
+		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
+		if err != nil {
+			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: err.Error()})
+			continue
+		}
+
+		for _, singleError := range fileErrors.Errors {
+			var lineNo = 0
+			if singleError.LineNumber > 0 {
+				lineNo = singleError.LineNumber
 			}
+			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("%s:%d:%d: %s: %s", relativeFilePath, lineNo, 0, "error", singleError.Message)})
 		}
 	}
 
@@ -180,18 +186,20 @@ func FormatErrorsAsCodeclimate(errors []ValidationErrors, config config.Config) 
 	var codeclimateIssues []CodeclimateIssue
 
 	for _, fileErrors := range errors {
-		if len(fileErrors.Errors) > 0 {
-			relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
-			if err != nil {
-				config.Logger.Error(err.Error())
-				continue
-			}
+		if len(fileErrors.Errors) == 0 {
+			continue
+		}
 
-			fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
+		relativeFilePath, err := files.GetRelativePath(fileErrors.FilePath)
+		if err != nil {
+			config.Logger.Error(err.Error())
+			continue
+		}
 
-			for _, singleError := range fileErrors.Errors {
-				codeclimateIssues = append(codeclimateIssues, newCodeclimateIssue(singleError, relativeFilePath))
-			}
+		fileErrors.Errors = ConsolidateErrors(fileErrors.Errors, config)
+
+		for _, singleError := range fileErrors.Errors {
+			codeclimateIssues = append(codeclimateIssues, newCodeclimateIssue(singleError, relativeFilePath))
 		}
 	}
 

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -169,7 +169,7 @@ func FormatErrorsAsGCC(errors []ValidationErrors, config config.Config) []logger
 		}
 
 		for _, singleError := range fileErrors.Errors {
-			var lineNo = 0
+			lineNo := 0
 			if singleError.LineNumber > 0 {
 				lineNo = singleError.LineNumber
 			}

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -191,7 +191,6 @@ func FormatErrorsAsCodeclimate(errors []ValidationErrors, config config.Config) 
 			for _, singleError := range fileErrors.Errors {
 				codeclimateIssues = append(codeclimateIssues, newCodeclimateIssue(singleError, relativeFilePath))
 			}
-
 		}
 	}
 

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -105,15 +105,17 @@ func FormatErrorsAsHumanReadable(errors []ValidationErrors, config config.Config
 
 		formatted_errors = append(formatted_errors, logger.LogMessage{Level: "warning", Message: fmt.Sprintf("%s:", relativeFilePath)})
 		for _, singleError := range fileErrors.Errors {
-			if singleError.LineNumber != -1 {
-				if singleError.AdditionalIdenticalErrorCount != 0 {
-					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d-%d: %s", singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
-				} else {
-					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message)})
-				}
-			} else {
+			if singleError.LineNumber == -1 {
 				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%s", singleError.Message)})
+				continue
 			}
+
+			if singleError.AdditionalIdenticalErrorCount == 0 {
+				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d: %s", singleError.LineNumber, singleError.Message)})
+				continue
+			}
+
+			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("\t%d-%d: %s", singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
 		}
 	}
 
@@ -138,15 +140,17 @@ func FormatErrorsAsGHA(errors []ValidationErrors, config config.Config) []logger
 
 		// github-actions: A format dedicated for usage in Github Actions
 		for _, singleError := range fileErrors.Errors {
-			if singleError.LineNumber != -1 {
-				if singleError.AdditionalIdenticalErrorCount != 0 {
-					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d,endLine=%d::%s", relativeFilePath, singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
-				} else {
-					formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d::%s", relativeFilePath, singleError.LineNumber, singleError.Message)})
-				}
-			} else {
+			if singleError.LineNumber == -1 {
 				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s::%s", relativeFilePath, singleError.Message)})
+				continue
 			}
+
+			if singleError.AdditionalIdenticalErrorCount == 0 {
+				formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d::%s", relativeFilePath, singleError.LineNumber, singleError.Message)})
+				continue
+			}
+
+			formatted_errors = append(formatted_errors, logger.LogMessage{Level: "error", Message: fmt.Sprintf("::error file=%s,line=%d,endLine=%d::%s", relativeFilePath, singleError.LineNumber, singleError.LineNumber+singleError.AdditionalIdenticalErrorCount, singleError.Message)})
 		}
 	}
 

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -8,6 +8,7 @@ import (
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/outputformat"
 )
 
 // ValidationError represents one validation error
@@ -209,14 +210,14 @@ func FormatErrorsAsCodeclimate(errors []ValidationErrors, config config.Config) 
 // FormatErrors prints the errors to the console
 func FormatErrors(errors []ValidationErrors, config config.Config) []logger.LogMessage {
 	switch config.Format {
-	case "codeclimate":
+	case outputformat.Codeclimate:
 		// codeclimate: A format that is compatible with the codeclimate format for GitLab CI.
 		// https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool
 		return FormatErrorsAsCodeclimate(errors, config)
-	case "gcc":
+	case outputformat.GCC:
 		// gcc: A format mimicking the error format from GCC.
 		return FormatErrorsAsGCC(errors, config)
-	case "github-actions":
+	case outputformat.GithubActions:
 		// github-actions: A format dedicated for usage in Github Actions
 		return FormatErrorsAsGHA(errors, config)
 	default:

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -222,7 +222,6 @@ func TestConsolidatingInterleavedErrors(t *testing.T) {
 }
 
 func TestFormatErrors(t *testing.T) {
-
 	/*
 		why change directory?
 		The relative path conversion done by FormatErrors() changes how absolute paths
@@ -315,18 +314,18 @@ func TestFormatErrors(t *testing.T) {
 		},
 	}
 
-	// wannabe test
-	config1 := config.Config{}
-	s.MatchSnapshot(t, FormatErrors(input, config1))
-
-	config2 := config.Config{Format: "gcc"}
-	s.MatchSnapshot(t, FormatErrors(input, config2))
-
-	config3 := config.Config{Format: "github-actions"}
-	s.MatchSnapshot(t, FormatErrors(input, config3))
-
-	config4 := config.Config{Format: "codeclimate"}
-	s.MatchSnapshot(t, FormatErrors(input, config4))
+	t.Run("default", func(t *testing.T) {
+		s.MatchSnapshot(t, FormatErrors(input, config.Config{}))
+	})
+	t.Run("codeclimate", func(t *testing.T) {
+		s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: "codeclimate"}))
+	})
+	t.Run("gcc", func(t *testing.T) {
+		s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: "gcc"}))
+	})
+	t.Run("github-actions", func(t *testing.T) {
+		s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: "github-actions"}))
+	})
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/outputformat"
 	"github.com/gkampitakis/go-snaps/snaps"
 )
 
@@ -314,18 +315,11 @@ func TestFormatErrors(t *testing.T) {
 		},
 	}
 
-	t.Run("default", func(t *testing.T) {
-		s.MatchSnapshot(t, FormatErrors(input, config.Config{}))
-	})
-	t.Run("codeclimate", func(t *testing.T) {
-		s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: "codeclimate"}))
-	})
-	t.Run("gcc", func(t *testing.T) {
-		s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: "gcc"}))
-	})
-	t.Run("github-actions", func(t *testing.T) {
-		s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: "github-actions"}))
-	})
+	for _, format := range outputformat.ValidOutputFormats {
+		t.Run(string(format), func(t *testing.T) {
+			s.MatchSnapshot(t, FormatErrors(input, config.Config{Format: format}))
+		})
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/outputformat/__snapshots__/output_formats_test.snap
+++ b/pkg/outputformat/__snapshots__/output_formats_test.snap
@@ -1,0 +1,4 @@
+
+[TestGetArgumentChoiceText - 1]
+default, codeclimate, gcc, github-actions
+---

--- a/pkg/outputformat/__snapshots__/outputformat_test.snap
+++ b/pkg/outputformat/__snapshots__/outputformat_test.snap
@@ -1,0 +1,4 @@
+
+[TestGetArgumentChoiceText - 1]
+default, codeclimate, gcc, github-actions
+---

--- a/pkg/outputformat/outputformat.go
+++ b/pkg/outputformat/outputformat.go
@@ -1,0 +1,55 @@
+// Package for having structured access to our output formats
+package outputformat
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type OutputFormat string
+
+const (
+	Default       = OutputFormat("default")
+	Codeclimate   = OutputFormat("codeclimate")
+	GCC           = OutputFormat("gcc")
+	GithubActions = OutputFormat("github-actions")
+)
+
+var ValidOutputFormats = []OutputFormat{
+	Default,
+	Codeclimate,
+	GCC,
+	GithubActions,
+}
+
+func GetArgumentChoiceText() string {
+	var output_strings []string
+	for _, f := range ValidOutputFormats {
+		output_strings = append(output_strings, string(f))
+	}
+	return strings.Join(output_strings, ", ")
+}
+
+func (format OutputFormat) MarshalText() ([]byte, error) {
+	if !format.IsValid() {
+		return nil, fmt.Errorf("%q is not a valid output format", format)
+	}
+	return []byte(format), nil
+}
+
+func (format *OutputFormat) UnmarshalText(data []byte) error {
+	*format = OutputFormat(string(data))
+	if !format.IsValid() {
+		return fmt.Errorf("%q is not a valid output format", data)
+	}
+	return nil
+}
+
+func (format OutputFormat) IsValid() bool {
+	return slices.Contains(ValidOutputFormats, format)
+}
+
+func (f OutputFormat) String() string {
+	return string(f)
+}

--- a/pkg/outputformat/outputformat_test.go
+++ b/pkg/outputformat/outputformat_test.go
@@ -1,0 +1,58 @@
+package outputformat
+
+import (
+	"testing"
+
+	"github.com/gkampitakis/go-snaps/snaps"
+)
+
+func TestIsValid(t *testing.T) {
+	for _, f := range ValidOutputFormats {
+		if !f.IsValid() {
+			t.Errorf("builtin value %s was not found valid. IsValid() is broken", string(f))
+		}
+	}
+
+	if OutputFormat("nonexistant value").IsValid() {
+		t.Error("failed to recognize an invalid value")
+	}
+}
+
+func TestGetArgumentChoiceText(t *testing.T) {
+	snaps.MatchSnapshot(t, GetArgumentChoiceText())
+}
+
+func TestMarshalling(t *testing.T) {
+	for _, f := range ValidOutputFormats {
+		// converting the builtin output formats to text must work
+		m, marshalerror := f.MarshalText()
+		if marshalerror != nil {
+			t.Error(marshalerror)
+		}
+
+		var u OutputFormat
+		unmarshalerror := u.UnmarshalText(m)
+		if unmarshalerror != nil {
+			t.Error(unmarshalerror)
+		}
+
+		if f != u {
+			t.Errorf("marshalling and then unmarshalling of format %s failed to survive the roundtrip", f)
+		}
+	}
+}
+
+func TestMarshallingBrokenInputFails(t *testing.T) {
+	broken := OutputFormat("invalid")
+	_, err := broken.MarshalText()
+	if err == nil {
+		t.Error("marshalling did not recognize an invalid value and marshalled it anyway")
+	}
+}
+func TestUnmarshallingBrokenInputFails(t *testing.T) {
+	var broken OutputFormat
+	err := broken.UnmarshalText([]byte("invalid"))
+	if err == nil {
+		t.Error("unmarshalling did not recognize an invalid value and unmarshalled it anyway")
+	}
+}


### PR DESCRIPTION
With this set of changes we should have a much more readable way of defining new output formats:
1. copy and paste a function in errors.go
2. add the format to `FormatErrors`' dispatching table
3. register the new format in output_formats.go's `ValidOutputFormats`
4. adjust README to document for the users
5. run the test suite allowing the snapshots to be updated

Adjusting the argument help text and adjusting the test suite of error.go is now automatic. 