### PR TITLE
chore: add a pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,17 @@ repos:
         args: []
   - repo: local
     hooks:
-      - id: no-FIXME
-        name: check for FIXME
-        description: 'Detect lines containing FIXME'
-        entry: 'FIXME'
+      - id: no-fixmes
+        name: check for fixmes
+        description: 'Detect lines containing uppercase fixme'
+        entry: '[F][I][X][M][E]'
         language: pygrep
         stages:
           - pre-commit
-      - id: no-TODO
-        name: check for TODO
-        description: 'Detect lines containing TODO'
-        entry: 'TODO'
+      - id: no-todo
+        name: check for todos
+        description: 'Detect lines containing uppercase todo'
+        entry: '[T][O][D][O]'
         language: pygrep
         stages:
           - pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,10 @@ repos:
         stages:
           - commit-msg
         args: []
+  - repo: https://github.com/pre-commit/pre-commit.git
+    rev: v3.8.0
+    hooks:
+      - id: validate_manifest
   - repo: local
     hooks:
       - id: pass-tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,20 +10,6 @@ repos:
         args: []
   - repo: local
     hooks:
-      - id: no-fixmes
-        name: check for fixmes
-        description: 'Detect lines containing uppercase fixme'
-        entry: '[F][I][X][M][E]'
-        language: pygrep
-        stages:
-          - pre-commit
-      - id: no-todo
-        name: check for todos
-        description: 'Detect lines containing uppercase todo'
-        entry: '[T][O][D][O]'
-        language: pygrep
-        stages:
-          - pre-commit
       - id: pass-tests
         name: Ensure the testsuite is passing
         entry: make test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages:
+          - commit-msg
+        args: []
+  - repo: local
+    hooks:
+      - id: no-FIXME
+        name: check for FIXME
+        description: 'Detect lines containing FIXME'
+        entry: 'FIXME'
+        language: pygrep
+        stages:
+          - pre-commit
+      - id: no-TODO
+        name: check for TODO
+        description: 'Detect lines containing TODO'
+        entry: 'TODO'
+        language: pygrep
+        stages:
+          - pre-commit
+      - id: pass-tests
+        name: Ensure the testsuite is passing
+        entry: make test
+        language: system
+        pass_filenames: false
+        stages:
+          - pre-commit
+

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: editorconfig-checker
+    name: run editorconfig-checker
+    description: This runs editorconfig-checker to validate files against your .editorconfig
+    language: golang
+    entry: editorconfig-checker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,3 +30,12 @@ The Pull Request must **pass all CI checks**, including tests and build.
 The commit messages should follow the [Conventional Commits](https://www.conventionalcommits.org/) format.
 
 Maintainers are responsible for reviewing and merging PRs, and they follow the [Maintainers](MAINTAINERS.md) guidelines.
+
+## Software development
+
+Our [Makefile](Makefile) provide a lot of targets that should prove helpful.
+- `make run` runs a typical use case of editorconfig-checker - in this case against this very repo
+- `make build` is a convenient shortcut to build the binary for your current platform
+- `make test` runs all the tests, govet and asks you to gofmt if you did not already
+
+If you want to run most of the checks the Continous Integration in GitHub does, you can also enable [pre-commit](https://pre-commit.com/). We provided a config that helps you notice problems with Conventional Commit messages or failing tests before you commit.


### PR DESCRIPTION
If any developer uses [pre-commit](https://pre-commit.com/) it reliably ensures that writing non-conventional commit messages do not happen, and that the testsuite passes.

~I also threw in two goodies of preventing TODO and FIXME occurances in newly added lines (and yes, I had to `git commit --no-verify` to actually make this commit).~

One word of caveat: these are of cause only local tests, and are not enforcable in any way, since they run on the committers machine. Enforcement still needs to happen in the CI.