### PR TITLE
chore: load codecov token from secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
       - run: make run
       - run: make bench
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
before merging this PR it would be good to head to https://app.codecov.io/gh/editorconfig-checker/editorconfig-checker/config/general and put the repository upload token into a GitHub secret named `CODECOV_TOKEN` (repeating that in the dependabot secrets). I think you @mstruebing or @theoludwig need to do this (I think only admins are allowed to access these sensitive parts).

This became necessary with the migration to `codecov-action@v4` in #323, since that migration no coverage uploads happened for the main branch, only ever for the PR branches, which do not need an upload token.