### PR TITLE
chore: pre-commit v2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
           - commit-msg
         args: []
   - repo: https://github.com/pre-commit/pre-commit.git
-    rev: v3.8.0
+    rev: v4.0.1
     hooks:
       - id: validate_manifest
   - repo: https://github.com/editorconfig-checker/editorconfig-checker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ repos:
     hooks:
       - id: validate_manifest
   - repo: https://github.com/editorconfig-checker/editorconfig-checker
-    rev: main
+    # after next release: replace with the newly created tag
+    rev: 10f16fc843581773830f0cbf3a3f8c285ee1edc3
     hooks:
       - id: editorconfig-checker
         stages:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@ repos:
     rev: v3.8.0
     hooks:
       - id: validate_manifest
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker
+    rev: main
+    hooks:
+      - id: editorconfig-checker
+        stages:
+          - pre-commit
   - repo: local
     hooks:
       - id: pass-tests


### PR DESCRIPTION
In this PR we extend our pre-commit testing to validate our own codebase using the pre-commit hook we also offer to others.

Technically this PR only add a single commit on top of #381.

This PR can only be merged when #383 is solved (so the plain `go install ./...` done by pre-commit works without running into errors due to version check failures) and #381 is merged (since without that merged the hook definition does not exist in the repo yet).

