### PR TITLE
fix: add `.ecrc` deprecation warning

### DIFF
--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -61,7 +61,6 @@ func init() {
 		configPaths = append(configPaths, defaultConfigFileNames[:]...)
 	} else {
 		configPaths = append(configPaths, configFilePath)
-
 	}
 
 	currentConfig, _ = config.NewConfig(configPaths)

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/error"
@@ -60,12 +61,14 @@ func init() {
 		configPaths = append(configPaths, defaultConfigFileNames[:]...)
 	} else {
 		configPaths = append(configPaths, configFilePath)
-		if configFilePath == ".ecrc" {
-			logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead.")
-		}
+
 	}
 
 	currentConfig, _ = config.NewConfig(configPaths)
+
+	if strings.Contains(currentConfig.Path, ".ecrc") {
+		logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead.  You can simply rename it")
+	}
 
 	if init {
 		err := currentConfig.Save(version)

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -67,7 +67,7 @@ func init() {
 	currentConfig, _ = config.NewConfig(configPaths)
 
 	if strings.Contains(currentConfig.Path, ".ecrc") {
-		logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead.  You can simply rename it")
+		logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead. You can simply rename it")
 	}
 
 	if init {

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -60,6 +60,9 @@ func init() {
 		configPaths = append(configPaths, defaultConfigFileNames[:]...)
 	} else {
 		configPaths = append(configPaths, configFilePath)
+		if configFilePath == ".ecrc" {
+			logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead.")
+		}
 	}
 
 	currentConfig, _ = config.NewConfig(configPaths)

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -65,7 +65,7 @@ func init() {
 
 	currentConfig, _ = config.NewConfig(configPaths)
 
-	if strings.Contains(currentConfig.Path, ".ecrc") {
+	if strings.HasSuffix(currentConfig.Path, ".ecrc") {
 		logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead. You can simply rename it")
 	}
 


### PR DESCRIPTION
Fixes #388 

> In https://github.com/editorconfig-checker/editorconfig-checker/pull/375, a new configuration file has been added: .editorconfig-checker.json.
> 
> In v4.0.0, we plan to drop the naming ec to use editorconfig-checker (https://github.com/editorconfig-checker/editorconfig-checker/pull/371), so we thought that we should deprecate usage of .ecrc, so that we can remove it in v4.0.0.
> 
> However, currently it is only deprecated in the README.md, we should deprecate it at runtime, by emitting a warning so that it will be easier for users to upgrade.
> 
> Similarly, it has been suggested to emit warnings in https://github.com/editorconfig-checker/editorconfig-checker/pull/386.
> 