### PR TITLE
fix: improve default excludes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ If you choose to [ignore them](#ignoring-default-excludes), these paths are excl
 "^package-lock\\.json$",
 "^composer\\.lock$",
 "^Cargo\\.lock$",
+"^Gemfile\\.lock$",
 "^\\.pnp\\.cjs$",
 "^\\.pnp\\.js$",
 "^\\.pnp\\.loader\\.mjs$",
@@ -306,11 +307,11 @@ If you choose to [ignore them](#ignoring-default-excludes), these paths are excl
 "\\.jpg$",
 "\\.jpeg$",
 "\\.webp$",
-"\\.avif",
-"\\.pnm",
-"\\.pbm",
-"\\.pgm",
-"\\.ppm",
+"\\.avif$",
+"\\.pnm$",
+"\\.pbm$",
+"\\.pgm$",
+"\\.ppm$",
 "\\.mp4$",
 "\\.wmv$",
 "\\.svg$",
@@ -328,7 +329,7 @@ If you choose to [ignore them](#ignoring-default-excludes), these paths are excl
 "\\.css\\.map$",
 "\\.js\\.map$",
 "min\\.css$",
-"min\\.js$"
+"min\\.js$",
 ```
 
 #### Ignoring Default Excludes

--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ add x y =
 If you choose to [ignore them](#ignoring-default-excludes), these paths are excluded automatically:
 
 ```txt
+"\\.git[\\/]",
 "^\\.yarn/",
 "^yarn\\.lock$",
 "^package-lock\\.json$",

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ If you choose to [ignore them](#ignoring-default-excludes), these paths are excl
 
 ```txt
 "\\.git[\\/]",
+"[\\/]node_modules[\\/]",
 "^\\.yarn/",
 "^yarn\\.lock$",
 "^package-lock\\.json$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var DefaultExcludes = strings.Join(defaultExcludes, "|")
 // defaultExcludes are an array to produce the correct string from
 var defaultExcludes = []string{
 	"\\.git[\\/]",
+	"[\\/]node_modules[\\/]",
 	"^\\.yarn/",
 	"^yarn\\.lock$",
 	"^package-lock\\.json$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ var DefaultExcludes = strings.Join(defaultExcludes, "|")
 
 // defaultExcludes are an array to produce the correct string from
 var defaultExcludes = []string{
+	"\\.git[\\/]",
 	"^\\.yarn/",
 	"^yarn\\.lock$",
 	"^package-lock\\.json$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,7 +86,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|testdata|\.git[\/]|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^Gemfile\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.pnm$|\.pbm$|\.pgm$|\.ppm$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|testdata|\.git[\/]|[\/]node_modules[\/]|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^Gemfile\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.pnm$|\.pbm$|\.pgm$|\.ppm$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,7 +86,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|testdata|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^Gemfile\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.pnm$|\.pbm$|\.pgm$|\.ppm$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|testdata|\.git[\/]|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^Gemfile\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.pnm$|\.pbm$|\.pgm$|\.ppm$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
After reading through past issues, I came to the conclusion that we should exclude both `.git` (#268 ) and `node_modules` (#197) by default. 