### PR TITLE
fix: empty format in the config file should be treated as Default

### DIFF
--- a/pkg/outputformat/outputformat.go
+++ b/pkg/outputformat/outputformat.go
@@ -2,6 +2,7 @@
 package outputformat
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -39,11 +40,7 @@ func (format OutputFormat) MarshalText() ([]byte, error) {
 }
 
 func (format *OutputFormat) UnmarshalText(data []byte) error {
-	formatValue := string(data)
-	if formatValue == "" {
-		formatValue = "default"
-	}
-	*format = OutputFormat(formatValue)
+	*format = OutputFormat(cmp.Or(string(data), "default"))
 	if !format.IsValid() {
 		return fmt.Errorf("%q is not a valid output format", data)
 	}

--- a/pkg/outputformat/outputformat.go
+++ b/pkg/outputformat/outputformat.go
@@ -39,7 +39,11 @@ func (format OutputFormat) MarshalText() ([]byte, error) {
 }
 
 func (format *OutputFormat) UnmarshalText(data []byte) error {
-	*format = OutputFormat(string(data))
+	formatValue := string(data)
+	if formatValue == "" {
+		formatValue = "default"
+	}
+	*format = OutputFormat(formatValue)
 	if !format.IsValid() {
 		return fmt.Errorf("%q is not a valid output format", data)
 	}

--- a/pkg/outputformat/outputformat_test.go
+++ b/pkg/outputformat/outputformat_test.go
@@ -56,3 +56,14 @@ func TestUnmarshallingBrokenInputFails(t *testing.T) {
 		t.Error("unmarshalling did not recognize an invalid value and unmarshalled it anyway")
 	}
 }
+
+func TestUnmarshallingEmptyFormat(t *testing.T) {
+	var working OutputFormat
+	err := working.UnmarshalText([]byte(""))
+	if err != nil {
+		t.Errorf("unmarshalling an empty string as the default output format failed: %v", err)
+	}
+	if working != Default {
+		t.Error("unmarshalling an empty string did not return the default output format")
+	}
+}


### PR DESCRIPTION
Some of our users have an empty Format in their config file - this should be treated as having requested the "default" output format, as it would be when the option is missing entirely.

Closes #430