### PR TITLE
ci: extend the CI to windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,15 @@ jobs:
       - run: make test
       - run: make run
       - run: make bench
+
+  ci-windows:
+    name: CI on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: "go.mod"
+      - run: make test
+      - run: make run
+      - run: make bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
     name: CI on Windows
     runs-on: windows-latest
     steps:
+      - run: |
+          git config --system core.autocrlf false
+          git config --system core.eol lf
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:


### PR DESCRIPTION
Broken out of #440, since windows needs more work than MacOS, and we do not want failing CI in the main branch.