### PR TITLE
feat: add `.jj` (Jujutsu) directory to default exclude list

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ If you choose to [ignore them](#ignoring-default-excludes), these paths are excl
 
 ```txt
 "\\.git[\\/]",
+"^\\.jj/",
 "[\\/]node_modules[\\/]",
 "^\\.yarn/",
 "^yarn\\.lock$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,6 +22,7 @@ var DefaultExcludes = strings.Join(defaultExcludes, "|")
 // defaultExcludes are an array to produce the correct string from
 var defaultExcludes = []string{
 	"\\.git[\\/]",
+	"^\\.jj/",
 	"[\\/]node_modules[\\/]",
 	"^\\.yarn/",
 	"^yarn\\.lock$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,7 +86,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|testdata|\.git[\/]|[\/]node_modules[\/]|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^Gemfile\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.pnm$|\.pbm$|\.pgm$|\.ppm$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
+	expected = `testfiles|testdata|\.git[\/]|^\.jj/|[\/]node_modules[\/]|^\.yarn/|^yarn\.lock$|^package-lock\.json$|^composer\.lock$|^Cargo\.lock$|^Gemfile\.lock$|^\.pnp\.cjs$|^\.pnp\.js$|^\.pnp\.loader\.mjs$|\.snap$|\.otf$|\.woff$|\.woff2$|\.eot$|\.ttf$|\.gif$|\.png$|\.jpg$|\.jpeg$|\.webp$|\.avif$|\.pnm$|\.pbm$|\.pgm$|\.ppm$|\.mp4$|\.wmv$|\.svg$|\.ico$|\.bak$|\.bin$|\.pdf$|\.zip$|\.gz$|\.tar$|\.7z$|\.bz2$|\.log$|\.patch$|\.css\.map$|\.js\.map$|min\.css$|min\.js$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
Adds Jujutsu's `.jj` directory to the default list of ignored files. [Jujutsu](https://jj-vcs.github.io/jj/latest/) (`jj`) is a version control system that maintains its metadata in a .jj directory, similar to how Git uses `.git`. Excluding this directory by default prevents accidental inclusion of VCS metadata in file operations where such files should typically be ignored.