### PR TITLE
ci: separate lint commit message in its own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6.2.1
+
   ci:
     name: CI on Linux
     runs-on: ubuntu-latest
@@ -14,8 +22,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6.2.1
-        if: ${{ github.ref != 'refs/heads/main' }}
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
It might be better to separate in its own job, the linting of the commit message. That way, we can more easily see what really fails, if it's only the commit message, then it "doesn't matter too much", as we squash and take the PR title as commit message when merging.