### PR TITLE
Update default excludes config.go to include Golang go.work and go.work.sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ If you choose to [ignore them](#ignoring-default-excludes), these paths are excl
 // RubyGems (Ruby)
 "Gemfile\\.lock$",
 // Go Modules (Go)
-"go\\.(mod|sum)$",
+"go\\.(mod|sum|work|work\\.sum)$",
 // Gradle (Java)
 "gradle/wrapper/gradle-wrapper\\.properties$",
 "gradlew(\\.bat)?$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,7 +32,7 @@ var defaultExcludes = []string{
 	// RubyGems (Ruby)
 	"Gemfile\\.lock$",
 	// Go Modules (Go)
-	"go\\.(mod|sum)$",
+	"go\\.(mod|sum|work|work\\.sum)$",
 	// Gradle (Java)
 	"gradle/wrapper/gradle-wrapper\\.properties$",
 	"gradlew(\\.bat)?$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -86,7 +86,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|testdata|\.git/|\.jj/|Cargo\.lock$|composer\.lock$|Gemfile\.lock$|go\.(mod|sum)$|gradle/wrapper/gradle-wrapper\.properties$|gradlew(\.bat)?$|(buildscript-)?gradle\.lockfile?$|\.mvn/wrapper/maven-wrapper\.properties$|\.mvn/wrapper/MavenWrapperDownloader\.java$|mvnw(\.cmd)?$|/node_modules/|npm-shrinkwrap\.json$|package-lock\.json$|Pipfile\.lock$|poetry\.lock$|pnpm-lock\.yaml$|\.terraform\.lock\.hcl$|uv\.lock$|\.pnp\.c?js$|\.pnp\.loader\.mjs$|\.yarn/|yarn\.lock$|\.eot$|\.otf$|\.ttf$|\.woff2?$|\.avif$|\.gif$|\.ico$|\.jpe?g$|\.mp4$|\.p[bgnp]m$|\.png$|\.svg$|\.tiff?$|\.webp$|\.wmv$|\.bak$|\.bin$|\.docx?$|\.exe$|\.pdf$|\.snap$|\.xlsx?$|\.7z$|\.bz2$|\.gz$|\.jar$|\.tar$|\.tgz$|\.war$|\.zip$|\.log$|\.patch$|\.(css|js)\.map$|min\.(css|js)$`
+	expected = `testfiles|testdata|\.git/|\.jj/|Cargo\.lock$|composer\.lock$|Gemfile\.lock$|go\.(mod|sum|work|work\.sum)$|gradle/wrapper/gradle-wrapper\.properties$|gradlew(\.bat)?$|(buildscript-)?gradle\.lockfile?$|\.mvn/wrapper/maven-wrapper\.properties$|\.mvn/wrapper/MavenWrapperDownloader\.java$|mvnw(\.cmd)?$|/node_modules/|npm-shrinkwrap\.json$|package-lock\.json$|Pipfile\.lock$|poetry\.lock$|pnpm-lock\.yaml$|\.terraform\.lock\.hcl$|uv\.lock$|\.pnp\.c?js$|\.pnp\.loader\.mjs$|\.yarn/|yarn\.lock$|\.eot$|\.otf$|\.ttf$|\.woff2?$|\.avif$|\.gif$|\.ico$|\.jpe?g$|\.mp4$|\.p[bgnp]m$|\.png$|\.svg$|\.tiff?$|\.webp$|\.wmv$|\.bak$|\.bin$|\.docx?$|\.exe$|\.pdf$|\.snap$|\.xlsx?$|\.7z$|\.bz2$|\.gz$|\.jar$|\.tar$|\.tgz$|\.war$|\.zip$|\.log$|\.patch$|\.(css|js)\.map$|min\.(css|js)$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)


### PR DESCRIPTION
Per this discussion https://github.com/editorconfig/editorconfig-core-go/pull/210#discussion_r2075830931 and suggestion from @generalmimon 

This updates the default https://github.com/editorconfig-checker/editorconfig-checker/tree/f1ae05b9aee4fd6404a398687cb05cf1d8df4158?tab=readme-ov-file#default-excludes

> 
> > Linting with [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) (or [super-linter](https://github.com/super-linter/super-linter) which uses that) complained about our `go.work` and `go.work.sum`) lead me here.
> 
> If you're looking for a solution for [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker) specifically, I think the right way would be to make a pull request that adds `go.work{,.sum}` to `defaultExcludes`. The `go.{mod,sum}` files are already there, so it makes a lot of sense:
> 
> [`config.go:19-23`](https://github.com/editorconfig-checker/editorconfig-checker/blob/f1ae05b9aee4fd6404a398687cb05cf1d8df4158/pkg/config/config.go#L19-L23)
> 
> ```go
> // DefaultExcludes is the regular expression for ignored files
> var DefaultExcludes = strings.Join(defaultExcludes, "|")
> 
> // defaultExcludes are an array to produce the correct string from
> var defaultExcludes = []string{
> ```
> 
> [`config.go:34-35`](https://github.com/editorconfig-checker/editorconfig-checker/blob/f1ae05b9aee4fd6404a398687cb05cf1d8df4158/pkg/config/config.go#L34-L35)
> 
> ```go
> 	// Go Modules (Go)
> 	"go\\.(mod|sum)$",
> ```
> 
> These "default excludes" are also mentioned in the README: [**editorconfig-checker** / Default Excludes](https://github.com/editorconfig-checker/editorconfig-checker/tree/f1ae05b9aee4fd6404a398687cb05cf1d8df4158?tab=readme-ov-file#default-excludes)
