### PR TITLE
perf: process files concurrently

### DIFF
--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"io/fs"
 	"os"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 
@@ -42,15 +43,19 @@ const (
 )
 
 // these must be globals, since they are referenced by init(), parseArguments
-var configFilePath string
-var cmdlineExclude string
-var cmdlineConfig config.Config
-var writeConfigFile bool
+var (
+	configFilePath  string
+	cmdlineExclude  string
+	cmdlineConfig   config.Config
+	writeConfigFile bool
+	cpuprofile      string
+)
 
 func enableNoColor(string) error {
 	cmdlineConfig.NoColor = true
 	return nil
 }
+
 func disableNoColor(string) error {
 	cmdlineConfig.NoColor = false
 	return nil
@@ -78,6 +83,7 @@ func init() {
 	flag.BoolVar(&cmdlineConfig.Disable.Indentation, "disable-indentation", false, "disables the indentation check")
 	flag.BoolVar(&cmdlineConfig.Disable.IndentSize, "disable-indent-size", false, "disables only the indent-size check")
 	flag.BoolVar(&cmdlineConfig.Disable.MaxLineLength, "disable-max-line-length", false, "disables only the max-line-length check")
+	flag.StringVar(&cpuprofile, "cpuprofile", "", "write cpu profile to file")
 }
 
 // parse the arguments from os.Args
@@ -103,7 +109,7 @@ func parseArguments() {
 
 	flag.Parse()
 
-	var configPaths = []string{}
+	configPaths := []string{}
 	if configFilePath == "" {
 		configPaths = append(configPaths, defaultConfigFileNames[:]...)
 	} else {
@@ -155,6 +161,18 @@ func parseArguments() {
 func main() {
 	parseArguments()
 
+	if cpuprofile != "" {
+		f, err := os.Create(cpuprofile)
+		if err != nil {
+			currentConfig.Logger.Error("Creating CPU profile file %s: %v", cpuprofile, err.Error())
+			exitProxy(exitCodeErrorOccurred)
+		}
+		if err := pprof.StartCPUProfile(f); err != nil {
+			currentConfig.Logger.Error("Starting CPU profile: %v", err.Error())
+			exitProxy(exitCodeErrorOccurred)
+		}
+	}
+
 	config := *currentConfig
 	config.Logger.Debug("Config: %s", config)
 	config.Logger.Verbose("Exclude Regexp: %s", config.GetExcludesAsRegularExpression())
@@ -173,7 +191,6 @@ func main() {
 
 	// contains all files which should be checked
 	filePaths, err := files.GetFiles(config)
-
 	if err != nil {
 		config.Logger.Error("%v", err.Error())
 		exitProxy(exitCodeErrorOccurred)
@@ -192,6 +209,10 @@ func main() {
 	eccerror.PrintErrors(errors, config)
 
 	config.Logger.Verbose("%d files checked", len(filePaths))
+
+	if cpuprofile != "" {
+		pprof.StopCPUProfile()
+	}
 
 	if eccerror.GetErrorCount(errors) != 0 {
 		exitProxy(exitCodeErrorOccurred)

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -174,6 +174,12 @@ func main() {
 	}
 
 	config := *currentConfig
+	// force the exclude regexp to be compiled and cached
+	if _, err := config.CachedExcludesAsRegexp(); err != nil {
+		config.Logger.Error("Compiling exclude regexp: %v", err.Error())
+		exitProxy(exitCodeErrorOccurred)
+	}
+
 	config.Logger.Debug("Config: %s", config)
 	config.Logger.Verbose("Exclude Regexp: %s", config.GetExcludesAsRegularExpression())
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,7 +141,7 @@ type Config struct {
 	Disable             DisabledChecks
 
 	// MISC
-	Logger             logger.Logger
+	Logger             *logger.Logger
 	EditorconfigConfig *editorconfig.Config
 
 	// CACHE
@@ -181,6 +181,8 @@ func NewConfig(configPaths []string) *Config {
 		configPath = configPaths[0]
 	}
 	config.Path = configPath
+
+	config.Logger = logger.GetLogger()
 
 	return &config
 }
@@ -273,7 +275,10 @@ func (c *Config) Merge(config Config) {
 
 	c.mergeDisabled(config.Disable)
 
-	c.Logger.Configure(logger.Logger{
+	if c.Logger == nil {
+		c.Logger = logger.GetLogger()
+	}
+	c.Logger.Configure(&logger.Logger{
 		VerboseEnabled: c.Verbose || config.Verbose,
 		DebugEnabled:   c.Debug || config.Debug,
 		NoColor:        c.NoColor || config.NoColor,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,14 +7,17 @@ import (
 	"testing"
 
 	// x-release-please-start-major
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/logger"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/outputformat"
 	// x-release-please-end
 
 	"github.com/gkampitakis/go-snaps/snaps"
 )
 
-var rootConfigFilePath = []string{"../../.editorconfig-checker.json"}
-var configWithIgnoredDefaults = []string{"../../testfiles/.editorconfig-checker.json"}
+var (
+	rootConfigFilePath        = []string{"../../.editorconfig-checker.json"}
+	configWithIgnoredDefaults = []string{"../../testfiles/.editorconfig-checker.json"}
+)
 
 func TestNewConfig(t *testing.T) {
 	actual := NewConfig([]string{"abc"})
@@ -134,6 +137,7 @@ func TestMerge(t *testing.T) {
 			IndentSize:             true,
 			MaxLineLength:          true,
 		},
+		Logger: logger.GetLogger(),
 	}
 
 	modifiedConfig.Merge(mergeConfig)

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -176,7 +176,7 @@ func TestConsolidateErrors(t *testing.T) {
 		{LineNumber: 6, Message: errors.New("message kind one")},
 	}
 
-	actual := ConsolidateErrors(input, config.Config{})
+	actual := ConsolidateErrors(input, *config.NewConfig(nil))
 
 	if !slices.EqualFunc(expected, actual, func(e1 ValidationError, e2 ValidationError) bool { return e1.Equal(e2) }) {
 		t.Log("consolidation expectation          :", expected)
@@ -206,7 +206,7 @@ func TestConsolidateErrorCounts(t *testing.T) {
 		{LineNumber: 9, AdditionalIdenticalErrorCount: 2, Message: errors.New("wrong indentation type")},
 	}
 
-	actual := ConsolidateErrors(input, config.Config{})
+	actual := ConsolidateErrors(input, *config.NewConfig(nil))
 
 	if !slices.EqualFunc(expected, actual, func(e1 ValidationError, e2 ValidationError) bool { return e1.Equal(e2) }) {
 		t.Log("consolidation expectation          :", expected)
@@ -248,7 +248,7 @@ func TestConsolidatingInterleavedErrors(t *testing.T) {
 		{LineNumber: 5, AdditionalIdenticalErrorCount: 0, Message: errors.New("message kind 1")},
 	}
 
-	actual := ConsolidateErrors(input, config.Config{})
+	actual := ConsolidateErrors(input, *config.NewConfig(nil))
 
 	if !slices.EqualFunc(expected, actual, func(e1 ValidationError, e2 ValidationError) bool { return e1.Equal(e2) }) {
 		t.Log("consolidation expectation          :", expected)
@@ -344,9 +344,10 @@ func TestFormatErrors(t *testing.T) {
 	for _, format := range outputformat.ValidOutputFormats {
 		t.Run(string(format), func(t *testing.T) {
 			buffer := bytes.Buffer{}
-			config := config.Config{Format: format}
+			config := config.NewConfig(nil)
+			config.Format = format
 			config.Logger.SetWriter(&buffer)
-			PrintErrors(input, config)
+			PrintErrors(input, *config)
 			s.MatchSnapshot(t, buffer.String())
 		})
 	}
@@ -367,10 +368,10 @@ func TestPrintErrorCount(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			buffer := bytes.Buffer{}
-			var config config.Config
+			config := config.NewConfig(nil)
 			config.Logger.VerboseEnabled = test.verbose
 			config.Logger.SetWriter(&buffer)
-			PrintErrorCount(test.errorcount, config)
+			PrintErrorCount(test.errorcount, *config)
 			snaps.MatchSnapshot(t, buffer.String())
 		})
 	}

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -3,8 +3,8 @@ package files
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -185,18 +185,18 @@ func GetContentType(path string) (string, error) {
 		return "", nil
 	}
 
-	rawFileContent, err := os.ReadFile(path)
+	fileContent, err := os.OpenFile(path, os.O_RDONLY, 0)
 	if err != nil {
 		panic(err)
 	}
-	return GetContentTypeBytes(rawFileContent)
+	defer fileContent.Close()
+
+	return GetContentTypeBytes(fileContent)
 }
 
 // GetContentTypeBytes returns the content type of a byte slice
-func GetContentTypeBytes(rawFileContent []byte) (string, error) {
-	bytesReader := bytes.NewReader(rawFileContent)
-
-	mimeType, err := mimetype.DetectReader(bytesReader)
+func GetContentTypeBytes(fileContent io.Reader) (string, error) {
+	mimeType, err := mimetype.DetectReader(fileContent)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -63,7 +63,7 @@ func AddToFiles(filePaths []string, filePath string, config config.Config) []str
 		return filePaths
 	}
 
-	contentType, err := GetContentType(filePath, config)
+	contentType, err := GetContentType(filePath)
 	if err != nil {
 		config.Logger.Error("Could not get the ContentType of file: %s", filePath)
 		config.Logger.Error("%v", err.Error())
@@ -167,7 +167,7 @@ func ReadLines(content string) []string {
 }
 
 // GetContentType returns the content type of a file
-func GetContentType(path string, config config.Config) (string, error) {
+func GetContentType(path string) (string, error) {
 	fileStat, err := os.Stat(path)
 	if err != nil {
 		return "", err
@@ -185,11 +185,11 @@ func GetContentType(path string, config config.Config) (string, error) {
 	if err != nil {
 		panic(err)
 	}
-	return GetContentTypeBytes(rawFileContent, config)
+	return GetContentTypeBytes(rawFileContent)
 }
 
 // GetContentTypeBytes returns the content type of a byte slice
-func GetContentTypeBytes(rawFileContent []byte, config config.Config) (string, error) {
+func GetContentTypeBytes(rawFileContent []byte) (string, error) {
 	bytesReader := bytes.NewReader(rawFileContent)
 
 	mimeType, err := mimetype.DetectReader(bytesReader)

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -44,12 +43,11 @@ func IsExcluded(filePath string, config config.Config) (bool, error) {
 		return true, err
 	}
 
-	result, err := regexp.MatchString(config.GetExcludesAsRegularExpression(), relativeFilePath)
+	re, err := config.CachedExcludesAsRegexp()
 	if err != nil {
 		return true, err
 	}
-
-	return result, nil
+	return re.MatchString(relativeFilePath), nil
 }
 
 // AddToFiles adds a file to a slice if it isn't already in there

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -148,8 +148,10 @@ func TestGetRelativePath(t *testing.T) {
 }
 
 func TestAddToFiles(t *testing.T) {
-	configuration := config.Config{}
-	excludedFileConfiguration := config.Config{Exclude: []string{"files"}}
+	configuration := config.NewConfig(nil)
+	configuration.AllowedContentTypes = nil
+	excludedFileConfiguration := config.NewConfig(nil)
+	excludedFileConfiguration.Exclude = []string{"files"}
 	addToFilesTests := []struct {
 		filePaths []string
 		filePath  string
@@ -159,13 +161,13 @@ func TestAddToFiles(t *testing.T) {
 		{
 			[]string{},
 			"./files.go",
-			excludedFileConfiguration,
+			*excludedFileConfiguration,
 			[]string{},
 		},
 		{
 			[]string{"./files.go"},
 			"./files.go",
-			configuration,
+			*configuration,
 			[]string{"./files.go"},
 		},
 	}
@@ -182,23 +184,21 @@ func TestAddToFiles(t *testing.T) {
 }
 
 func TestGetFiles(t *testing.T) {
-	configurations := []config.Config{
-		{},
-		{
-			PassedFiles: []string{"./../../docs/"},
-		},
+	docsConfig := config.NewConfig(nil)
+	docsConfig.PassedFiles = []string{"./../../docs/"}
+	configurations := []*config.Config{
+		config.NewConfig(nil),
+		docsConfig,
 	}
 
 	for _, configuration := range configurations {
-		configuration := configuration
-
-		_, err := GetFiles(configuration)
+		_, err := GetFiles(*configuration)
 		if err != nil {
 			t.Errorf("GetFiles(): expected nil, got %s", err.Error())
 		}
 
 		configuration.PassedFiles = []string{"."}
-		files, err := GetFiles(configuration)
+		files, err := GetFiles(*configuration)
 
 		if len(files) > 0 && err != nil {
 			t.Errorf("GetFiles(.): expected nil, got %s", err.Error())

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -14,35 +14,34 @@ import (
 )
 
 func TestGetContentType(t *testing.T) {
-	configuration := config.Config{}
 	inputFile := "./files.go"
 	expected := "text/plain"
-	contentType, _ := GetContentType(inputFile, configuration)
+	contentType, _ := GetContentType(inputFile)
 	if !strings.Contains(contentType, expected) {
 		t.Errorf("GetContentType(%q): expected %v, got %v", inputFile, expected, contentType)
 	}
 
 	inputFile = "./../../docs/logo.png"
 	expected = "image/png"
-	contentType, _ = GetContentType(inputFile, configuration)
+	contentType, _ = GetContentType(inputFile)
 	if !strings.Contains(contentType, expected) {
 		t.Errorf("GetContentType(%q): expected %v, got %v", inputFile, expected, contentType)
 	}
 
 	inputFile = "."
-	_, err := GetContentType(inputFile, configuration)
+	_, err := GetContentType(inputFile)
 	if err == nil {
 		t.Errorf("GetContentType(%q): expected %v, got %v", inputFile, "an error", "nil")
 	}
 
 	inputFile = "a non-existent file"
-	_, err = GetContentType(inputFile, configuration)
+	_, err = GetContentType(inputFile)
 	if err == nil {
 		t.Errorf("GetContentType(%q): expected %v, got %v", inputFile, "an error", "nil")
 	}
 
 	inputFile = "testdata/empty.txt"
-	contentType, err = GetContentType(inputFile, configuration)
+	contentType, err = GetContentType(inputFile)
 	if err != nil {
 		t.Errorf("GetContentType(%q): expected %v, got %v", inputFile, "nil", err.Error())
 	}
@@ -117,7 +116,7 @@ func TestGetRelativePath(t *testing.T) {
 	}
 	DIR += "/tmp/stuff"
 	os.Remove(DIR)
-	err := os.Mkdir(DIR, 0755)
+	err := os.Mkdir(DIR, 0o755)
 	if err != nil {
 		panic(err)
 	}
@@ -268,10 +267,9 @@ var getContentTypeFilesTests = []getContentTypeFilesTest{
 }
 
 func TestGetContentTypeFiles(t *testing.T) {
-	configuration := config.Config{}
 	for _, tt := range getContentTypeFilesTests {
 		filePath := "../encoding/testdata/" + tt.filename
-		contentType, err := GetContentType(filePath, configuration)
+		contentType, err := GetContentType(filePath)
 		if err != nil {
 			t.Errorf("GetContentType(%q): expected %v, got %v", tt.filename, "nil", err.Error())
 		}

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -23,11 +23,11 @@ func snapHelper(t *testing.T, logger *Logger, test loggerTest) {
 func TestLoggerDebug(t *testing.T) {
 	logger := GetLogger()
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.Debug("this text should not be printed by a logger with default config")
 	})
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.DebugEnabled = true
 		logger.Debug("this text should be printed when debug was enabled")
 	})
@@ -36,11 +36,11 @@ func TestLoggerDebug(t *testing.T) {
 func TestLoggerVerbose(t *testing.T) {
 	logger := GetLogger()
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.Verbose("this text should not be printed by a logger with default config")
 	})
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.VerboseEnabled = true
 		logger.Verbose("hello")
 	})
@@ -49,11 +49,11 @@ func TestLoggerVerbose(t *testing.T) {
 func TestLoggerWarning(t *testing.T) {
 	logger := GetLogger()
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.Warning("this text should be printed by a logger with default config %s", "(and in color)")
 	})
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.NoColor = true
 		logger.Warning("this text should be printed by a logger with default config %s", "(but not be colorized)")
 	})
@@ -62,18 +62,18 @@ func TestLoggerWarning(t *testing.T) {
 func TestLoggerOutput(t *testing.T) {
 	logger := GetLogger()
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.Output("plain output should be printed always %s", "(also supporting format strings)")
 	})
 }
 
 func TestLoggerError(t *testing.T) {
 	logger := GetLogger()
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.Error("this text should be printed by a logger with default config %s", "(and in color)")
 	})
 
-	snapHelper(t, &logger, func() {
+	snapHelper(t, logger, func() {
 		logger.NoColor = true
 		logger.Error("this text should be printed by a logger with default config %s", "(but not be colorized)")
 	})
@@ -100,7 +100,7 @@ func TestConfigure(t *testing.T) {
 		t.Errorf("Assumption broken: writer was set already")
 	}
 
-	configLogger := Logger{
+	configLogger := &Logger{
 		VerboseEnabled: true,
 		DebugEnabled:   true,
 		NoColor:        true,

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -2,6 +2,7 @@
 package validation
 
 import (
+	"bytes"
 	"os"
 	"regexp"
 	"runtime"
@@ -70,7 +71,7 @@ func ValidateFileWithDefinition(filePath string, config config.Config, def *edit
 		panic(err)
 	}
 	fileContent := string(rawFileContent)
-	mime, err := files.GetContentTypeBytes(rawFileContent)
+	mime, err := files.GetContentTypeBytes(bytes.NewReader(rawFileContent))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -47,7 +47,7 @@ func ValidateFile(filePath string, config config.Config) []error.ValidationError
 		panic(err)
 	}
 	fileContent := string(rawFileContent)
-	mime, err := files.GetContentTypeBytes(rawFileContent, config)
+	mime, err := files.GetContentTypeBytes(rawFileContent)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -4,8 +4,10 @@ package validation
 import (
 	"os"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	// x-release-please-start-major
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
@@ -31,7 +33,28 @@ var textRegexes = []string{
 }
 
 // ValidateFile Validates a single file and returns the errors
+// Note: This function is not thread safe, so it should not be called concurrently
 func ValidateFile(filePath string, config config.Config) []error.ValidationError {
+	// idiomatic Go allows empty struct
+	if config.EditorconfigConfig == nil {
+		config.EditorconfigConfig = &editorconfig.Config{}
+	}
+
+	// EditorconfigConfig isn't thread safe, so we need to lock it
+	def, warnings, err := config.EditorconfigConfig.LoadGraceful(filePath)
+	if err != nil {
+		config.Logger.Error("cannot load %s as .editorconfig: %s", filePath, err)
+		return nil
+	}
+	if warnings != nil {
+		config.Logger.Warning("%v", warnings.Error())
+	}
+
+	return ValidateFileWithDefinition(filePath, config, def)
+}
+
+// ValidateFileWithDefinition Validates a single file with a given editorconfig definition and returns the errors
+func ValidateFileWithDefinition(filePath string, config config.Config, def *editorconfig.Definition) []error.ValidationError {
 	const directivePrefix = "editorconfig-checker-"
 	const directiveDisable = directivePrefix + "disable"
 	const directiveDisableFile = directivePrefix + "disable-file"
@@ -73,27 +96,13 @@ func ValidateFile(filePath string, config config.Config) []error.ValidationError
 		return validationErrors
 	}
 
-	// idiomatic Go allows empty struct
-	if config.EditorconfigConfig == nil {
-		config.EditorconfigConfig = &editorconfig.Config{}
-	}
-
-	definition, warnings, err := config.EditorconfigConfig.LoadGraceful(filePath)
-	if err != nil {
-		config.Logger.Error("cannot load %s as .editorconfig: %s", filePath, err)
-		return validationErrors
-	}
-	if warnings != nil {
-		config.Logger.Warning("%v", warnings.Error())
-	}
-
-	fileInformation := files.FileInformation{Content: fileContent, FilePath: filePath, Editorconfig: definition}
+	fileInformation := files.FileInformation{Content: fileContent, FilePath: filePath, Editorconfig: def}
 	validationError := ValidateFinalNewline(fileInformation, config)
 	if validationError.Message != nil {
 		validationErrors = append(validationErrors, validationError)
 	}
 
-	fileInformation = files.FileInformation{Content: fileContent, FilePath: filePath, Editorconfig: definition}
+	fileInformation = files.FileInformation{Content: fileContent, FilePath: filePath, Editorconfig: def}
 	validationError = ValidateLineEnding(fileInformation, config)
 	if validationError.Message != nil {
 		validationErrors = append(validationErrors, validationError)
@@ -153,7 +162,7 @@ func ValidateFile(filePath string, config config.Config) []error.ValidationError
 			}
 		}
 
-		fileInformation = files.FileInformation{Line: line, FilePath: filePath, LineNumber: lineNumber, Editorconfig: definition}
+		fileInformation = files.FileInformation{Line: line, FilePath: filePath, LineNumber: lineNumber, Editorconfig: def}
 		validationError = ValidateTrailingWhitespace(fileInformation, config)
 		if validationError.Message != nil {
 			validationErrors = append(validationErrors, validationError)
@@ -249,12 +258,57 @@ func ValidateMaxLineLength(fileInformation files.FileInformation, config config.
 
 // ProcessValidation Validates all files and returns an array of validation errors
 func ProcessValidation(files []string, config config.Config) []error.ValidationErrors {
-	var validationErrors []error.ValidationErrors
-
-	for _, filePath := range files {
-		config.Logger.Verbose("Validate %s", filePath)
-		validationErrors = append(validationErrors, error.ValidationErrors{FilePath: filePath, Errors: ValidateFile(filePath, config)})
+	// idiomatic Go allows empty struct
+	if config.EditorconfigConfig == nil {
+		config.EditorconfigConfig = &editorconfig.Config{}
 	}
 
-	return validationErrors
+	var (
+		validationErrors = make([]*error.ValidationErrors, len(files))
+		wg               sync.WaitGroup
+		lock             sync.Mutex
+	)
+	// Limit the number of concurrent goroutines to the number of CPUs
+	limiter := make(chan struct{}, runtime.NumCPU())
+
+	for i, filePath := range files {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Wait for a slot to be available in the limiter, and release it via defer
+			limiter <- struct{}{}
+			defer func() { <-limiter }()
+
+			config.Logger.Verbose("Validate %s", filePath)
+
+			// EditorconfigConfig isn't thread safe, so we need to acquire a lock
+			lock.Lock()
+			def, warnings, err := config.EditorconfigConfig.LoadGraceful(filePath)
+			lock.Unlock()
+			if err != nil {
+				config.Logger.Error("cannot load %s as .editorconfig: %s", filePath, err)
+				return
+			}
+			if warnings != nil {
+				config.Logger.Warning("%v", warnings.Error())
+			}
+			errors := ValidateFileWithDefinition(filePath, config, def)
+
+			lock.Lock()
+			validationErrors[i] = &error.ValidationErrors{FilePath: filePath, Errors: errors}
+			lock.Unlock()
+		}()
+	}
+
+	wg.Wait()
+
+	// Remove all nil values
+	result := make([]error.ValidationErrors, 0, len(validationErrors))
+	for _, validationError := range validationErrors {
+		if validationError != nil {
+			result = append(result, *validationError)
+		}
+	}
+
+	return result
 }

--- a/pkg/validation/validation_test.go
+++ b/pkg/validation/validation_test.go
@@ -9,150 +9,163 @@ import (
 )
 
 func TestProcessValidation(t *testing.T) {
-	configuration := config.Config{
-		Verbose: true,
-	}
+	configuration := config.NewConfig(nil)
+	configuration.Verbose = true
 
-	processValidationResult := ProcessValidation([]string{"./../../cmd/editorconfig-checker/main.go"}, configuration)
+	processValidationResult := ProcessValidation([]string{"./../../cmd/editorconfig-checker/main.go"}, *configuration)
 	if len(processValidationResult) > 1 || len(processValidationResult[0].Errors) != 0 {
 		t.Error("Should not have errors when validating main.go, got", processValidationResult)
 	}
 
-	processValidationResult = ProcessValidation([]string{"./../../testfiles/disabled-file.ext"}, configuration)
+	processValidationResult = ProcessValidation([]string{"./../../testfiles/disabled-file.ext"}, *configuration)
 	if len(processValidationResult) > 1 || len(processValidationResult[0].Errors) != 0 {
 		t.Error("Disabled file should have no errors, got", processValidationResult)
 	}
 
-	processValidationResult = ProcessValidation([]string{"./../../testfiles/empty-file.txt"}, configuration)
+	processValidationResult = ProcessValidation([]string{"./../../testfiles/empty-file.txt"}, *configuration)
 	if len(processValidationResult) > 1 || len(processValidationResult[0].Errors) != 0 {
 		t.Error("Empty file should have no errors, got", processValidationResult)
 	}
 
-	processValidationResult = ProcessValidation([]string{"./../../testfiles/wrong-file.txt"}, configuration)
+	processValidationResult = ProcessValidation([]string{"./../../testfiles/wrong-file.txt"}, *configuration)
 	if (len(processValidationResult) > 1) || (len(processValidationResult[0].Errors) != 1) {
 		t.Error("Wrong file should have errors, got", processValidationResult)
 	}
 }
 
 func TestValidateFile(t *testing.T) {
-	configuration := config.Config{Verbose: true}
+	configuration := config.NewConfig(nil)
+	configuration.Verbose = true
 
-	result := ValidateFile("./../../cmd/editorconfig-checker/main.go", configuration)
+	result := ValidateFile("./../../cmd/editorconfig-checker/main.go", *configuration)
 	if len(result) != 0 {
 		t.Error("Should not have errors when validating main.go, got", result)
 	}
 
-	result = ValidateFile("./../../testfiles/wrong-file.txt", configuration)
+	result = ValidateFile("./../../testfiles/wrong-file.txt", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have errors when validating file with one error, got", result)
 	}
 
 	configuration.Disable.Indentation = true
-	result = ValidateFile("./../../testfiles/wrong-file.txt", configuration)
+	result = ValidateFile("./../../testfiles/wrong-file.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no errors, got", result)
 	}
 
-	configuration = config.Config{SpacesAfterTabs: true}
-	result = ValidateFile("./../../testfiles/spaces-after-tabs.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.SpacesAfterTabs = true
+	result = ValidateFile("./../../testfiles/spaces-after-tabs.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no errors when validating valid file, got", result)
 	}
 
-	configuration = config.Config{SpacesAfterTabs: false}
-	result = ValidateFile("./../../testfiles/zero-indent.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.SpacesAfterTabs = false
+	result = ValidateFile("./../../testfiles/zero-indent.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no errors when validating valid file, got", result)
 	}
 
-	result = ValidateFile("./../../testfiles/disabled-line.txt", configuration)
+	result = ValidateFile("./../../testfiles/disabled-line.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no errors when validating valid file, got", result)
 	}
 
-	result = ValidateFile("./../../testfiles/disabled-next-line.txt", configuration)
+	result = ValidateFile("./../../testfiles/disabled-next-line.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no errors when validating valid file, got", result)
 	}
 
-	result = ValidateFile("./../../testfiles/disabled-block.txt", configuration)
+	result = ValidateFile("./../../testfiles/disabled-block.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no errors when validating valid file, got", result)
 	}
 
-	result = ValidateFile("./../../testfiles/disabled-block-with-error.txt", configuration)
+	result = ValidateFile("./../../testfiles/disabled-block-with-error.txt", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have one error, got", result)
 	}
 
-	configuration = config.Config{SpacesAfterTabs: false}
-	result = ValidateFile("./../../testfiles/spaces-after-tabs.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.SpacesAfterTabs = false
+	result = ValidateFile("./../../testfiles/spaces-after-tabs.txt", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have one error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
-	result = ValidateFile("./../../testfiles/trailing-whitespace.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
+	result = ValidateFile("./../../testfiles/trailing-whitespace.txt", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have one error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
 	configuration.Disable.TrimTrailingWhitespace = true
-	result = ValidateFile("./../../testfiles/trailing-whitespace.txt", configuration)
+	result = ValidateFile("./../../testfiles/trailing-whitespace.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
-	result = ValidateFile("./../../testfiles/final-newline-missing.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
+	result = ValidateFile("./../../testfiles/final-newline-missing.txt", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have one error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
 	configuration.Disable.InsertFinalNewline = true
-	result = ValidateFile("./../../testfiles/final-newline-missing.txt", configuration)
+	result = ValidateFile("./../../testfiles/final-newline-missing.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
-	result = ValidateFile("./../../testfiles/wrong-line-ending.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
+	result = ValidateFile("./../../testfiles/wrong-line-ending.txt", *configuration)
 	if len(result) == 0 {
 		t.Error("Should have one error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
-	result = ValidateFile("./../../testfiles/wrong-next-line.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
+	result = ValidateFile("./../../testfiles/wrong-next-line.txt", *configuration)
 	nbExpectedError := 2
 	if len(result) != nbExpectedError {
 		t.Errorf("Should have %d error, got %v", nbExpectedError, result)
 	}
 
-	configuration = config.Config{Verbose: true}
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
 	configuration.Disable.EndOfLine = true
 	configuration.Disable.InsertFinalNewline = true
-	result = ValidateFile("./../../testfiles/wrong-line-ending.txt", configuration)
+	result = ValidateFile("./../../testfiles/wrong-line-ending.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
-	result = ValidateFile("./../../testfiles/line-to-long.txt", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
+	result = ValidateFile("./../../testfiles/line-to-long.txt", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have one error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
 	configuration.Disable.MaxLineLength = true
-	result = ValidateFile("./../../testfiles/line-to-long.txt", configuration)
+	result = ValidateFile("./../../testfiles/line-to-long.txt", *configuration)
 	if len(result) != 0 {
 		t.Error("Should have no error, got", result)
 	}
 
-	configuration = config.Config{Verbose: true}
-	result = ValidateFile("./../../testfiles/spaces-with-tab.c", configuration)
+	configuration = config.NewConfig(nil)
+	configuration.Verbose = true
+	result = ValidateFile("./../../testfiles/spaces-with-tab.c", *configuration)
 	if len(result) != 1 {
 		t.Error("Should have one error, got", result)
 	}


### PR DESCRIPTION
Fixes https://github.com/editorconfig-checker/editorconfig-checker/issues/276

This makes the whole run sub 2s on my "big"-ish project, instead of the previous ~30s, via a couple of tweaks:
1. Early skip a whole dir in the initial walking of the files, if it matches the exclude pattern
2. Process files concurrently
3. Pre-compile some regexps (it misses the indentation regexp, which is dynamic, but we could maybe pre-compile a couple of them (eg. 2 / 4 / 8)
4. Use a stream in `GetContentTypeBytes` so we don't need to read the whole file

It also adds a new `--cpuprofile` flag to write a CPU profile of the run to the given filepath