### PR TITLE
fix: remove duplicated arch from ec-compat binary name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ builds:
   # this build is used to provide the legacy-style archives
   - id: "ec-compat"
     main: ./cmd/editorconfig-checker
-    binary: bin/ec-{{- .Os }}-{{ .Arch }}{{- if .Arm }}v{{ .Arm }}{{ end }}
+    binary: ec
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
## Summary

The ec-compat release archives (e.g. `ec-linux-amd64.tar.gz`) contain a binary named `bin/ec-linux-amd64`, duplicating the OS/architecture info already present in the archive filename. This prevents tools like [eget](https://github.com/zyedidia/eget) from cleanly installing the binary as just `ec`.

Changed the goreleaser ec-compat binary template from `bin/ec-{{.Os}}-{{.Arch}}` to `ec` so the archive contains a cleanly named `ec` binary.

The main `editorconfig-checker` build is unaffected. Only the legacy ec-compat archives change.

Fixes #208

This contribution was developed with AI assistance (Claude Code).