### PR TITLE
feat(files): expand glob patterns in passed-file args (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ A sample configuration file can look like this and will be used from your curren
 | `NoColor` | bool | `false` | Disable colored output |
 | `Exclude` | string[] | `[]` | Regular expressions for files to exclude from checking |
 | `AllowedContentTypes` | string[] | `[]` | Additional content types to check (added to the defaults listed below) |
-| `PassedFiles` | string[] | `[]` | Explicit list of files or directories to check. When set, only these paths are checked instead of auto-discovering files from the working directory or git |
+| `PassedFiles` | string[] | `[]` | Explicit list of files, directories, or shell-style glob patterns (e.g. `src/*.go`) to check. When set, only these paths are checked instead of auto-discovering files from the working directory or git. Glob patterns that don't match any file are left as-is so a subsequent content-type check surfaces the missing path |
 | `Version` | string | `""` | When set, the tool verifies this value matches the binary version and exits with an error if they differ. Useful for pinning a specific version in CI |
 | `Disable` | object | | Selectively disable individual checks (see below) |
 

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -77,6 +77,44 @@ func AddToFiles(filePaths []string, filePath string, config config.Config) []str
 	return append(filePaths, filePath)
 }
 
+// hasGlobMeta reports whether the path contains any of the glob metacharacters
+// recognized by filepath.Match / filepath.Glob: '*', '?', '['.
+func hasGlobMeta(path string) bool {
+	for i := 0; i < len(path); i++ {
+		switch path[i] {
+		case '*', '?', '[':
+			return true
+		case '\\':
+			if i+1 < len(path) {
+				i++
+			}
+		}
+	}
+	return false
+}
+
+// resolvePassedFile expands a single --passed-file argument into one or more
+// concrete paths. Paths that exist on disk are returned unchanged. Paths that
+// don't exist but look like glob patterns are expanded via filepath.Glob; if
+// the pattern matches nothing the argument is returned unchanged so the caller
+// can surface a not-found error in the usual way.
+func resolvePassedFile(passedFile string) ([]string, error) {
+	if _, err := os.Stat(passedFile); err == nil {
+		return []string{passedFile}, nil
+	}
+	if !hasGlobMeta(passedFile) {
+		return []string{passedFile}, nil
+	}
+	matches, err := filepath.Glob(passedFile)
+	if err != nil {
+		return nil, fmt.Errorf("invalid pattern %q: %w", passedFile, err)
+	}
+	if len(matches) == 0 {
+		return []string{passedFile}, nil
+	}
+	return matches, nil
+}
+
 // GetFilesFromDirectory returns all files from a directory and its subdirectories which should be checked
 func GetFilesFromDirectory(rootDir string, config config.Config) ([]string, error) {
 	filePaths := make([]string, 0)
@@ -116,14 +154,20 @@ func GetFiles(config config.Config) ([]string, error) {
 	// Handle explicit passed files
 	if len(config.PassedFiles) != 0 {
 		for _, passedFile := range config.PassedFiles {
-			if !utils.IsDirectory(passedFile) {
-				filePaths = AddToFiles(filePaths, passedFile, config)
-			} else {
-				files, err := GetFilesFromDirectory(passedFile, config)
-				if err != nil {
-					return filePaths, err
+			resolved, err := resolvePassedFile(passedFile)
+			if err != nil {
+				return filePaths, err
+			}
+			for _, entry := range resolved {
+				if utils.IsDirectory(entry) {
+					files, err := GetFilesFromDirectory(entry, config)
+					if err != nil {
+						return filePaths, err
+					}
+					filePaths = append(filePaths, files...)
+				} else {
+					filePaths = AddToFiles(filePaths, entry, config)
 				}
-				filePaths = append(filePaths, files...)
 			}
 		}
 

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -208,6 +208,53 @@ func TestGetFiles(t *testing.T) {
 	}
 }
 
+func TestGetFilesGlobPattern(t *testing.T) {
+	globConfig := config.NewConfig(nil)
+	// Root-level markdown files (README.md, CHANGELOG.md, MAINTAINERS.md,
+	// CONTRIBUTING.md) exist relative to pkg/files when we walk up two levels.
+	globConfig.PassedFiles = []string{"./../../*.md"}
+
+	files, err := GetFiles(*globConfig)
+	if err != nil {
+		t.Fatalf("GetFiles(glob): expected nil, got %s", err.Error())
+	}
+	if len(files) == 0 {
+		t.Fatalf("GetFiles(glob): expected at least one match for ./../../*.md, got 0")
+	}
+	for _, f := range files {
+		if !strings.HasSuffix(f, ".md") {
+			t.Errorf("GetFiles(glob): expected .md matches only, got %q", f)
+		}
+	}
+}
+
+func TestGetFilesGlobWithoutMetaKeepsPath(t *testing.T) {
+	cfg := config.NewConfig(nil)
+	cfg.PassedFiles = []string{"./does/not/exist.txt"}
+
+	files, err := GetFiles(*cfg)
+	if err != nil {
+		t.Fatalf("GetFiles(missing): unexpected error %s", err.Error())
+	}
+	// Non-existent paths without glob metacharacters are passed straight to
+	// AddToFiles, which logs and drops them (they have no content type). The
+	// call should not fail and should not invent matches.
+	for _, f := range files {
+		if f == "./does/not/exist.txt" {
+			return
+		}
+	}
+}
+
+func TestGetFilesGlobNoMatchesKeepsPath(t *testing.T) {
+	cfg := config.NewConfig(nil)
+	cfg.PassedFiles = []string{"./nonexistent-prefix-*.xyz"}
+
+	if _, err := GetFiles(*cfg); err != nil {
+		t.Fatalf("GetFiles(no-match glob): unexpected error %s", err.Error())
+	}
+}
+
 type getContentTypeFilesTest struct {
 	filename string
 	regex    string

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -3,6 +3,7 @@ package files
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"runtime"
@@ -252,6 +253,88 @@ func TestGetFilesGlobNoMatchesKeepsPath(t *testing.T) {
 
 	if _, err := GetFiles(*cfg); err != nil {
 		t.Fatalf("GetFiles(no-match glob): unexpected error %s", err.Error())
+	}
+}
+
+func TestHasGlobMetaDetectsAllMetachars(t *testing.T) {
+	cases := []string{"*.go", "file?.txt", "log[0-9].txt", "a/b/c*"}
+	for _, p := range cases {
+		if !hasGlobMeta(p) {
+			t.Errorf("hasGlobMeta(%q): expected true, got false", p)
+		}
+	}
+	if hasGlobMeta("plain/path.txt") {
+		t.Errorf("hasGlobMeta(plain/path.txt): expected false, got true")
+	}
+}
+
+func TestHasGlobMetaSkipsEscapedMetachars(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("filepath.Match treats backslash as a path separator on Windows")
+	}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{`\*.go`, false},
+		{`\?.txt`, false},
+		{`\[abc\]`, false},
+		{`dir/\*`, false},
+		{`\`, false},
+		{`foo\*bar*`, true},
+	}
+	for _, tc := range cases {
+		if got := hasGlobMeta(tc.path); got != tc.want {
+			t.Errorf("hasGlobMeta(%q): got %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestResolvePassedFileInvalidPatternErrors(t *testing.T) {
+	_, err := resolvePassedFile("nonexistent-[unclosed")
+	if err == nil {
+		t.Fatalf("resolvePassedFile(invalid pattern): expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid pattern") {
+		t.Errorf("resolvePassedFile(invalid pattern): expected error to mention \"invalid pattern\", got %q", err.Error())
+	}
+}
+
+func TestGetFilesGlobPropagatesInvalidPattern(t *testing.T) {
+	cfg := config.NewConfig(nil)
+	cfg.PassedFiles = []string{"nonexistent-[unclosed"}
+
+	if _, err := GetFiles(*cfg); err == nil {
+		t.Fatalf("GetFiles(invalid pattern): expected error, got nil")
+	}
+}
+
+func TestGetFilesGlobMatchesDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "dirA")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("setup mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("setup writefile: %v", err)
+	}
+
+	cfg := config.NewConfig(nil)
+	cfg.PassedFiles = []string{filepath.Join(tmp, "dir*")}
+
+	files, err := GetFiles(*cfg)
+	if err != nil {
+		t.Fatalf("GetFiles(dir glob): unexpected error %s", err.Error())
+	}
+	found := false
+	for _, f := range files {
+		if strings.HasSuffix(f, "a.txt") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("GetFiles(dir glob): expected dir*/a.txt to be walked, got %v", files)
 	}
 }
 


### PR DESCRIPTION
## Summary

Expands shell-style glob patterns passed via `PassedFiles` (command-line args), so invocations like `editorconfig-checker 'src/*.go'` work even when the shell doesn't expand the pattern for us.

Closes #190

## Why

`PassedFiles` currently handles two cases - a file path or a directory path - and falls through to `AddToFiles` for anything else. A quoted glob pattern was passed straight to `os.Stat`, which failed, and then `GetContentType` surfaced the same path as a missing file. Issue #190 asked for inline glob support so users can narrow down a monorepo scan without invoking the shell.

## Changes

- `pkg/files/files.go`: new `hasGlobMeta` + `resolvePassedFile` helpers. In `GetFiles`, each passed file is first resolved to one or more concrete paths: existing paths pass through unchanged, glob-shaped paths go through `filepath.Glob`, and non-glob missing paths are returned as-is so the existing error path still fires.
- `pkg/files/files_test.go`: three new tests cover a matching glob (`./../../*.md`), a non-glob missing path (no expansion, existing behavior), and a no-match glob (no expansion).
- `README.md`: `PassedFiles` row updated to mention glob patterns and the no-match fallthrough.

## Testing

```
go test ./...                       # all packages green
go test ./pkg/files/ -v -run Glob   # new tests green
go vet ./...                        # clean
gofmt -l pkg/files/                 # clean
```

## Scope

`path/filepath.Glob` supports `*`, `?`, and `[...]`. It does not support `**` - supporting that would need a dependency (e.g. `doublestar`), which felt out of scope for this GFI. Users who need recursive matching can still pass a directory path and rely on the existing recursive walk.
