### PR TITLE
fix: anchor node_modules and target default excludes at path start

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Unless you choose to [ignore them](#ignoring-default-excludes), these paths are 
 // package manager, generated, & lock files
 // Cargo (Rust)
 "Cargo\\.lock$",
-"/target/",
+"(^|/)target/",
 // Composer (PHP)
 "composer\\.lock$",
 // RubyGems (Ruby)
@@ -410,7 +410,7 @@ Unless you choose to [ignore them](#ignoring-default-excludes), these paths are 
 "\\.mvn/wrapper/MavenWrapperDownloader\\.java$",
 "mvnw(\\.cmd)?$",
 // NodeJS
-"/node_modules/",
+"(^|/)node_modules/",
 // npm (NodeJS)
 "npm-shrinkwrap\\.json$",
 "package-lock\\.json$",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ var defaultExcludes = []string{
 	// package manager, generated, & lock files
 	// Cargo (Rust)
 	"Cargo\\.lock$",
-	"/target/",
+	"(^|/)target/",
 	// Composer (PHP)
 	"composer\\.lock$",
 	// RubyGems (Ruby)
@@ -44,7 +44,7 @@ var defaultExcludes = []string{
 	"\\.mvn/wrapper/MavenWrapperDownloader\\.java$",
 	"mvnw(\\.cmd)?$",
 	// NodeJS
-	"/node_modules/",
+	"(^|/)node_modules/",
 	// npm (NodeJS)
 	"npm-shrinkwrap\\.json$",
 	"package-lock\\.json$",

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"testing"
 
 	// x-release-please-start-major
@@ -89,7 +90,7 @@ func TestGetExcludesAsRegularExpression(t *testing.T) {
 	}
 
 	actual = c.GetExcludesAsRegularExpression()
-	expected = `testfiles|testdata|\.git/|\.jj/|Cargo\.lock$|/target/|composer\.lock$|Gemfile\.lock$|go\.(mod|sum|work|work\.sum)$|gradle/wrapper/gradle-wrapper\.properties$|gradlew(\.bat)?$|(buildscript-)?gradle\.lockfile?$|\.mvn/wrapper/maven-wrapper\.properties$|\.mvn/wrapper/MavenWrapperDownloader\.java$|mvnw(\.cmd)?$|/node_modules/|npm-shrinkwrap\.json$|package-lock\.json$|Pipfile\.lock$|poetry\.lock$|pnpm-lock\.yaml$|\.terraform\.lock\.hcl$|uv\.lock$|buf\.lock$|\.pnp\.c?js$|\.pnp\.loader\.mjs$|\.yarn/|yarn\.lock$|\.eot$|\.otf$|\.ttf$|\.woff2?$|\.avif$|\.gif$|\.ico$|\.jpe?g$|\.mp4$|\.p[bgnp]m$|\.png$|\.svg$|\.tiff?$|\.webp$|\.wmv$|\.bak$|\.bin$|\.docx?$|\.exe$|\.pdf$|\.snap$|\.xlsx?$|\.7z$|\.bz2$|\.gz$|\.jar$|\.tar$|\.tgz$|\.war$|\.zip$|\.log$|\.patch$|\.(css|js)\.map$|min\.(css|js)$|~$`
+	expected = `testfiles|testdata|\.git/|\.jj/|Cargo\.lock$|(^|/)target/|composer\.lock$|Gemfile\.lock$|go\.(mod|sum|work|work\.sum)$|gradle/wrapper/gradle-wrapper\.properties$|gradlew(\.bat)?$|(buildscript-)?gradle\.lockfile?$|\.mvn/wrapper/maven-wrapper\.properties$|\.mvn/wrapper/MavenWrapperDownloader\.java$|mvnw(\.cmd)?$|(^|/)node_modules/|npm-shrinkwrap\.json$|package-lock\.json$|Pipfile\.lock$|poetry\.lock$|pnpm-lock\.yaml$|\.terraform\.lock\.hcl$|uv\.lock$|buf\.lock$|\.pnp\.c?js$|\.pnp\.loader\.mjs$|\.yarn/|yarn\.lock$|\.eot$|\.otf$|\.ttf$|\.woff2?$|\.avif$|\.gif$|\.ico$|\.jpe?g$|\.mp4$|\.p[bgnp]m$|\.png$|\.svg$|\.tiff?$|\.webp$|\.wmv$|\.bak$|\.bin$|\.docx?$|\.exe$|\.pdf$|\.snap$|\.xlsx?$|\.7z$|\.bz2$|\.gz$|\.jar$|\.tar$|\.tgz$|\.war$|\.zip$|\.log$|\.patch$|\.(css|js)\.map$|min\.(css|js)$|~$`
 
 	if actual != expected {
 		t.Errorf("expected %s, got %s", expected, actual)
@@ -214,4 +215,33 @@ func TestString(t *testing.T) {
 	c.Format = outputformat.Default
 
 	snaps.MatchJSON(t, c.String())
+}
+
+func TestDefaultExcludesAnchoring(t *testing.T) {
+	re, err := regexp.Compile(DefaultExcludes)
+	if err != nil {
+		t.Fatalf("DefaultExcludes should compile, got: %v", err)
+	}
+
+	excluded := []string{
+		"node_modules/foo/index.js",
+		"packages/a/node_modules/foo/index.js",
+		"target/debug/main",
+		"crates/a/target/debug/main",
+	}
+	for _, path := range excluded {
+		if !re.MatchString(path) {
+			t.Errorf("expected %q to match the default excludes", path)
+		}
+	}
+
+	notExcluded := []string{
+		"my_node_modules/foo/index.js",
+		"not_target/main.go",
+	}
+	for _, path := range notExcluded {
+		if re.MatchString(path) {
+			t.Errorf("expected %q to not match the default excludes", path)
+		}
+	}
 }


### PR DESCRIPTION
## Problem

The default excludes `/node_modules/` and `/target/` start with a literal slash, but exclude patterns are matched against paths relative to the repository root. A top-level `node_modules/` directory produces paths like `node_modules/foo/index.js` with no slash before `node_modules`, so it was never excluded. Nested directories (`packages/a/node_modules/...`) were correctly excluded.

This only shows in directory-walk mode, since `git ls-files` already omits ignored files, which is why it went unnoticed. See #567 for the full analysis and reproduction.

## Fix

Anchor both patterns as `(^|/)node_modules/` and `(^|/)target/` so they match at the start of a relative path as well as after a slash, without matching names that merely end with the directory name (e.g. `my_node_modules/`).

- `pkg/config/config.go`: anchor the two patterns
- `pkg/config/config_test.go`: update the expected joined regex, add `TestDefaultExcludesAnchoring` covering top-level and nested paths plus the `my_node_modules`/`not_target` non-matches
- `README.md`: update the documented default excludes list

Verified against the reproduction from #567: a top-level `node_modules/foo/bad.js` without final newline is now excluded in walk mode (exit 0), and `go test ./pkg/...` passes.

Fixes #567