### PR TITLE
chore: add JSON schema for editorconfig-checker configuration

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,10 +1,11 @@
 {
+    "$schema": "./.editorconfig-checker.schema.json",
     "Verbose": false,
     "Debug": false,
     "IgnoreDefaults": false,
     "SpacesAfterTabs": false,
     "NoColor": false,
-    "exclude": [
+    "Exclude": [
         "testfiles",
         "testdata"
     ],

--- a/.editorconfig-checker.schema.json
+++ b/.editorconfig-checker.schema.json
@@ -1,0 +1,135 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "editorconfig-checker configuration",
+    "description": "Configuration for editorconfig-checker",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "$schema": {
+            "type": "string",
+            "description": "A field for the JSON schema specification."
+        },
+        "Version": {
+            "type": "string",
+            "default": "",
+            "description": "When set, the tool verifies this value matches the binary version and exits with an error if they differ. Useful for pinning a specific version in CI"
+        },
+        "Verbose": {
+            "type": "boolean",
+            "default": false,
+            "description": "Print verbose output during checking"
+        },
+        "Format": {
+            "type": "string",
+            "default": "default",
+            "description": "Specify the output format",
+            "enum": [
+                "",
+                "default",
+                "codeclimate",
+                "gcc",
+                "github-actions"
+            ]
+        },
+        "Debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Print debugging information"
+        },
+        "IgnoreDefaults": {
+            "type": "boolean",
+            "default": false,
+            "description": "Ignore the default exclude patterns"
+        },
+        "SpacesAfterTabs": {
+            "type": "boolean",
+            "default": false,
+            "description": "Allow spaces after tabs in indentation (mixed indentation). When `false`, spaces following tabs are flagged as errors"
+        },
+        "SpacesAftertabs": {
+            "type": "boolean",
+            "deprecated": true,
+            "description": "The configuration key `SpacesAftertabs` is deprecated. Use `SpacesAfterTabs` instead"
+        },
+        "NoColor": {
+            "type": "boolean",
+            "default": false,
+            "description": "Disable colored output"
+        },
+        "Exclude": {
+            "type": "array",
+            "default": [],
+            "description": "Regular expressions for files to exclude from checking",
+            "items": {
+                "type": "string"
+            }
+        },
+        "AllowedContentTypes": {
+            "type": "array",
+            "default": [],
+            "description": "Additional content types to check, added to the default allowed content types",
+            "items": {
+                "type": "string"
+            }
+        },
+        "PassedFiles": {
+            "type": "array",
+            "default": [],
+            "description": "Explicit list of files, directories, or shell-style glob patterns (e.g. `src/*.go`) to check. When set, only these paths are checked instead of auto-discovering files from the working directory or git. Glob patterns that don't match any file are left as-is so a subsequent content-type check surfaces the missing path",
+            "items": {
+                "type": "string"
+            }
+        },
+        "Disable": {
+            "type": "object",
+            "default": {
+                "Charset": false,
+                "EndOfLine": false,
+                "Indentation": false,
+                "InsertFinalNewline": false,
+                "TrimTrailingWhitespace": false,
+                "IndentSize": false,
+                "MaxLineLength": false
+            },
+            "description": "Set any of the options under the `Disable` section to `true` to disable those particular checks",
+            "additionalProperties": false,
+            "properties": {
+                "Charset": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables only the charset check"
+                },
+                "EndOfLine": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables the end-of-line check"
+                },
+                "Indentation": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables the indentation check"
+                },
+                "InsertFinalNewline": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables the final newline check"
+                },
+                "TrimTrailingWhitespace": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables the trailing whitespace check"
+                },
+                "IndentSize": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables only the indent-size check"
+                },
+                "MaxLineLength": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Disables only the max-line-length check"
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -250,8 +250,10 @@ The configuration is done via arguments or it will take the first config file fo
 
 A sample configuration file can look like this and will be used from your current working directory if not specified via the `--config` argument:
 
+<!-- x-release-please-start-version -->
 ```json
 {
+  "$schema": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/v3.7.0/.editorconfig-checker.schema.json",
   "Verbose": false,
   "Debug": false,
   "IgnoreDefaults": false,
@@ -271,6 +273,9 @@ A sample configuration file can look like this and will be used from your curren
   }
 }
 ```
+<!-- x-release-please-end -->
+
+The `$schema` property is an optional field for specifying the JSON Schema and is ignored by editorconfig-checker.
 
 ### Configuration Keys
 
@@ -481,13 +486,15 @@ If you either set `IgnoreDefaults` to `true` or pass the `-ignore-defaults` comm
 
 ##### via configuration
 
-In your [configuration file](#configuration) you can exclude files with the `"exclude"` key which takes an array of regular expressions.
+In your [configuration file](#configuration) you can exclude files with the `"Exclude"` key which takes an array of regular expressions.
 This will get merged with the default excludes (if not [ignored](#ignoring-default-excludes)). You should remember to escape your regular expressions correctly.
 
 A [configuration file](#configuration) which would ignore all test files and all Markdown files can look like this:
 
+<!-- x-release-please-start-version -->
 ```json
 {
+  "$schema": "https://raw.githubusercontent.com/editorconfig-checker/editorconfig-checker/v3.7.0/.editorconfig-checker.schema.json",
   "Verbose": false,
   "IgnoreDefaults": false,
   "Exclude": ["testfiles", "\\.md$"],
@@ -503,6 +510,7 @@ A [configuration file](#configuration) which would ignore all test files and all
   }
 }
 ```
+<!-- x-release-please-end -->
 
 ##### via arguments
 


### PR DESCRIPTION
close #194

This PR adds a JSON Schema for the editorconfig-checker JSON configuration file. This enables JSON Schema-aware editors and tools to validate `.editorconfig-checker.json` and provide completion for its configuration properties.

If this is accepted, it would be even more convenient to distribute versioned schemas from <https://editorconfig-checker.github.io/>, or to publish the schema through the [JSON Schema Store](https://www.schemastore.org/).
