### PR TITLE
chore: remove binary editorconfig-checker at root of repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin/
+editorconfig-checker
 editorconfig-checker.test
 coverage.txt
 result-bin


### PR DESCRIPTION
In 9f4014ce0 (#557) a 6.2MBytes editorconfig-checker binary has been introduced to the repository. Remove it and add the file to `.gitignore` to prevent it from being added later.