### PR TITLE
fix: handle `unset` for `end_of_line` and `insert_final_newline`

### DIFF
--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -102,7 +102,7 @@ func TrailingWhitespace(line string, trimTrailingWhitespace bool) error {
 
 // FinalNewline validates if a file has a final and correct newline
 func FinalNewline(fileContent string, insertFinalNewline string, endOfLine string) error {
-	if endOfLine != "" && insertFinalNewline == "true" {
+	if endOfLine != "" && endOfLine != "unset" && insertFinalNewline == "true" {
 		expectedEolChar := utils.GetEolChar(endOfLine)
 		if !strings.HasSuffix(fileContent, expectedEolChar) || (expectedEolChar == "\n" && strings.HasSuffix(fileContent, "\r\n")) {
 			return errors.New("Wrong line endings or no final newline")
@@ -124,7 +124,7 @@ func FinalNewline(fileContent string, insertFinalNewline string, endOfLine strin
 
 // LineEnding validates if a file uses the correct line endings
 func LineEnding(fileContent string, endOfLine string) error {
-	if endOfLine != "" {
+	if endOfLine != "" && endOfLine != "unset" {
 		expectedEolChar := utils.GetEolChar(endOfLine)
 		expectedEols := len(strings.Split(fileContent, expectedEolChar))
 		lfEols := len(strings.Split(fileContent, "\n"))

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -73,6 +73,14 @@ func TestFinalNewline(t *testing.T) {
 		{"x\r", "false", "", errors.New("No final newline expected")},
 		{"x\r\n", "true", "", nil},
 		{"x\r\n", "false", "", errors.New("No final newline expected")},
+		{"x", "true", "unset", errors.New("Final newline expected")},
+		{"x", "false", "unset", nil},
+		{"x\n", "true", "unset", nil},
+		{"x\n", "false", "unset", errors.New("No final newline expected")},
+		{"x\r", "true", "unset", nil},
+		{"x\r", "false", "unset", errors.New("No final newline expected")},
+		{"x\r\n", "true", "unset", nil},
+		{"x\r\n", "false", "unset", errors.New("No final newline expected")},
 	}
 
 	for _, tt := range finalNewlineTests {
@@ -106,6 +114,18 @@ func TestLineEnding(t *testing.T) {
 		{"x\r", "crlf", errors.New("Not all lines have the correct end of line character")},
 		{"x\n", "crlf", errors.New("Not all lines have the correct end of line character")},
 		{"x\ry\nz\n", "crlf", errors.New("Not all lines have the correct end of line character")},
+
+		{"x", "", nil},
+		{"x\n", "", nil},
+		{"x\r", "", nil},
+		{"x\r\n", "", nil},
+		{"x\ry\nz\n", "", nil},
+
+		{"x", "unset", nil},
+		{"x\n", "unset", nil},
+		{"x\r", "unset", nil},
+		{"x\r\n", "unset", nil},
+		{"x\ry\nz\n", "unset", nil},
 	}
 
 	for _, tt := range linedEndingTests {


### PR DESCRIPTION
The original assumption was, that setting an editorconfig option to
`unset` would mean that we read an empty string (the default string
value) from editorconfig-core. However, it seems the value is passed on
literally, which means that currently we need to handle this.

Fixes: #580
