### PR TITLE
fix!: do not accept latin1 files as utf-8

### DIFF
--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -4,7 +4,6 @@ package encoding
 import (
 	"bytes"
 	"fmt"
-	"slices"
 	"strings"
 	"unicode/utf8"
 
@@ -220,12 +219,6 @@ var (
 	encodingToDecoderMap map[string]string
 
 	supportedUTFEncodingMap map[string]string
-
-	latin1Encodings = []string{
-		CharsetLatin1,
-		"ascii",
-		"iso88591",
-	}
 )
 
 func init() {
@@ -276,8 +269,10 @@ func CharsetsMatch(charsetFound, charsetWanted string) bool {
 		}
 	}
 
-	// latin1 (iso88591), and ascii files are utf8 files, too.
-	if charsetWanted == "utf8" && slices.Contains(latin1Encodings, charsetFound) {
+	// ascii is a strict subset of utf8, so ascii files are utf8 files, too.
+	// latin1 (iso88591) files are not: a lone 0xA0 byte, for instance, is
+	// valid latin1 but is not valid utf8.
+	if charsetWanted == "utf8" && charsetFound == "ascii" {
 		return true
 	}
 

--- a/pkg/encoding/encoding_test.go
+++ b/pkg/encoding/encoding_test.go
@@ -156,6 +156,7 @@ func TestCharsetsMatch(t *testing.T) {
 		{CharsetLatin1, "iso88591", false},
 		{CharsetLatin1, "iso8859-1", false},
 		{CharsetLatin1, "iso-8859-1", false},
+		{CharsetLatin1, "utf-8", false}, // issue #597: latin1 is not a subset of utf-8
 		{CharsetUTF8, "utf8", true},
 		{CharsetUTF8BOM, "utf8bom", true},
 		{CharsetUTF8BOM, "utf-8bom", true},
@@ -186,9 +187,6 @@ func TestCharsetsMatch(t *testing.T) {
 	for _, charset1 := range ValidCharsets {
 		for _, charset2 := range ValidCharsets {
 			if charset1 != charset2 {
-				if charset1 == "latin1" && charset2 == "utf-8" {
-					continue
-				}
 				tests = append(tests, test{charset1, charset2, false})
 			}
 		}

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -295,3 +295,21 @@ func TestMaxLineLength(t *testing.T) {
 		}
 	}
 }
+
+// TestCharsetLatin1IsNotUtf8 guards issue #597: a file detected as ISO-8859-1
+// is not valid UTF-8 (e.g. a lone 0xA0 byte), so `charset = utf-8` must fail.
+func TestCharsetLatin1IsNotUtf8(t *testing.T) {
+	c := config.Config{}
+	if err := Charset("utf-8", "ISO-8859-1", c); err == nil {
+		t.Error(`Charset("utf-8", "ISO-8859-1"): expected an error, got nil`)
+	}
+	if err := Charset("utf-8", "ascii", c); err != nil {
+		t.Errorf(`Charset("utf-8", "ascii"): expected nil, got %v`, err)
+	}
+	if err := Charset("utf-8", "UTF-8", c); err != nil {
+		t.Errorf(`Charset("utf-8", "UTF-8"): expected nil, got %v`, err)
+	}
+	if err := Charset("latin1", "ISO-8859-1", c); err != nil {
+		t.Errorf(`Charset("latin1", "ISO-8859-1"): expected nil, got %v`, err)
+	}
+}


### PR DESCRIPTION
Fixes #597.

`CharsetsMatch` treats `latin1`, `iso88591` and `ascii` as all satisfying `charset = utf-8`:

    latin1Encodings = []string{CharsetLatin1, "ascii", "iso88591"}
    // latin1 (iso88591), and ascii files are utf8 files, too.
    if charsetWanted == "utf8" && slices.Contains(latin1Encodings, charsetFound) {
        return true
    }

For `ascii` that is sound — ascii is a strict subset of utf-8. For latin1 it is not. Every byte value 0x80–0xFF is a legal latin1 character, and most of them are not legal utf-8: a lone `0xA0` or `0xFF` will make Go, Python or a browser refuse to decode the file. So a file that nothing downstream can read as utf-8 passed the check silently. This drops latin1 and iso88591 from the exemption and keeps ascii.

### Before / after on the reporter's case

`.editorconfig` with `charset = utf-8`, three files — one latin1, one ascii, one utf-8:

| | before | after |
| --- | --- | --- |
| `latin1.txt` (`caf\xe9 na\xefve`) | not reported | `Wrong character encoding ("ISO-8859-1" instead of "utf-8")` |
| `ascii.txt` | not reported | not reported |
| `utf8.txt` (`caf\xc3\xa9`) | not reported | not reported |
| exit code | 0 | 1 |

### What this costs on real code

The risk with a change like this is new warnings on files people are happy with, so I measured it rather than guessing. I built the binary at `123ba31` and with this patch, pointed both at a corpus of **11 937 files** (this repository, three unrelated Python projects, and the full Go standard library source tree) under a `.editorconfig` forcing `charset = utf-8`, and diffed the two outputs:

    before: 524 errors found
    after:  525 errors found

**One** new warning, on:

    gosrc/cmd/go/testdata/script/get_panic_issue75251.txt:
        Wrong character encoding ("ISO-8859-1" instead of "utf-8")

That file is a Go test fixture containing three raw `0xFF` bytes; its own text says `# contains 0xff`. Python refuses it with `'utf-8' codec can't decode byte 0xff in position 163`. So the single new warning is a file that genuinely is not utf-8 — the new behaviour is right about it.

For completeness: 895 files in that corpus are not valid utf-8, but the rest are object files, `.syso` resources and pprof profiles, which the checker classifies as `binary` and reports identically before and after.

### Tests

`go test ./...`: **10 packages ok, 0 FAIL** — before and after.

The new expectations are in `pkg/encoding/encoding_test.go` and `pkg/validation/validators/validators_test.go`. Note that `TestCharsetsMatch` already enumerated this pair and skipped it:

    if charset1 == "latin1" && charset2 == "utf-8" {
        continue
    }

Removing that `continue` is what turns the test red on the current code (`CharsetsMatch("latin1", "utf-8"): got true, want false`) and green with the fix, so the existing table now covers the case instead of stepping around it.

`gofmt -l` and `go vet` are clean on the changed files. The commit follows the conventional-commit format that `commitlint` enforces here.

AI-assisted (LLM used for drafting); the measurements above are mine.

<!--
BEGIN_COMMIT_OVERRIDE
fix!: stop accepting latin1 files as utf-8. (#598)<br>Previously `charset=utf-8` was satisfied with files encoded as `latin1`. While most of the `latin1` range is identical to `utf-8`, not all is. If you request `utf-8` but have `latin1` encoded files expect these files to be reported as violations now.
END_COMMIT_OVERRIDE
-->