### PR TITLE
fix: drop a path whose content type could not be read

### DIFF
--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -65,10 +65,11 @@ func AddToFiles(filePaths []string, filePath string, config config.Config) []str
 	if err != nil {
 		config.Logger.Error("Could not get the ContentType of file: %s", filePath)
 		config.Logger.Error("%v", err.Error())
+		return filePaths
 	}
 	config.Logger.Debug("AddToFiles: detected ContentType %s on file %s", contentType, filePath)
 
-	if err == nil && !IsAllowedContentType(contentType, config) {
+	if !IsAllowedContentType(contentType, config) {
 		config.Logger.Verbose("Not adding %s to be checked, it does not have an allowed ContentType", filePath)
 		return filePaths
 	}

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -100,12 +100,16 @@ func hasGlobMeta(path string) bool {
 // named it explicitly. Patterns are expanded via filepath.Glob; one that
 // matches nothing is returned unchanged, so an empty match is not an error.
 func resolvePassedFile(passedFile string) ([]string, error) {
-	if _, err := os.Stat(passedFile); err == nil {
+	_, statErr := os.Stat(passedFile)
+	if statErr == nil {
 		return []string{passedFile}, nil
 	}
 	if !hasGlobMeta(passedFile) {
-		// A plain path that is not there is a typo, not a pattern that matched nothing.
-		return nil, fmt.Errorf("%s: no such file or directory", passedFile)
+		// A plain path that is not usable is a user error, not a pattern that
+		// matched nothing. Wrap the stat error so a cause other than a missing
+		// file, a permission denied on the parent directory for instance, is
+		// reported as it is.
+		return nil, fmt.Errorf("resolving %s: %w", passedFile, statErr)
 	}
 	matches, err := filepath.Glob(passedFile)
 	if err != nil {

--- a/pkg/files/files.go
+++ b/pkg/files/files.go
@@ -95,16 +95,17 @@ func hasGlobMeta(path string) bool {
 }
 
 // resolvePassedFile expands a single --passed-file argument into one or more
-// concrete paths. Paths that exist on disk are returned unchanged. Paths that
-// don't exist but look like glob patterns are expanded via filepath.Glob; if
-// the pattern matches nothing the argument is returned unchanged so the caller
-// can surface a not-found error in the usual way.
+// concrete paths. Paths that exist on disk are returned unchanged. A path that
+// does not exist and holds no glob metacharacters is an error, since the user
+// named it explicitly. Patterns are expanded via filepath.Glob; one that
+// matches nothing is returned unchanged, so an empty match is not an error.
 func resolvePassedFile(passedFile string) ([]string, error) {
 	if _, err := os.Stat(passedFile); err == nil {
 		return []string{passedFile}, nil
 	}
 	if !hasGlobMeta(passedFile) {
-		return []string{passedFile}, nil
+		// A plain path that is not there is a typo, not a pattern that matched nothing.
+		return nil, fmt.Errorf("%s: no such file or directory", passedFile)
 	}
 	matches, err := filepath.Glob(passedFile)
 	if err != nil {

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -235,21 +235,19 @@ func TestGetFilesGlobPattern(t *testing.T) {
 	}
 }
 
-func TestGetFilesGlobWithoutMetaKeepsPath(t *testing.T) {
+func TestGetFilesMissingPathWithoutMetaErrors(t *testing.T) {
 	cfg := config.NewConfig(nil)
 	cfg.PassedFiles = []string{"./does/not/exist.txt"}
 
-	files, err := GetFiles(*cfg)
-	if err != nil {
-		t.Fatalf("GetFiles(missing): unexpected error %s", err.Error())
+	// A path the user named explicitly, with no glob metacharacters, is a typo
+	// rather than a pattern that matched nothing, so it has to be an error.
+	// Previously it was passed on and silently dropped, and the run exited 0.
+	_, err := GetFiles(*cfg)
+	if err == nil {
+		t.Fatal("GetFiles(missing): expected an error for a path that does not exist, got nil")
 	}
-	// Non-existent paths without glob metacharacters are passed straight to
-	// AddToFiles, which logs and drops them (they have no content type). The
-	// call should not fail and should not invent matches.
-	for _, f := range files {
-		if f == "./does/not/exist.txt" {
-			t.Fatalf("GetFiles(missing): expected %q to be dropped, got: %v", "./does/not/exist.txt", files)
-		}
+	if !strings.Contains(err.Error(), "./does/not/exist.txt") {
+		t.Errorf("GetFiles(missing): error should name the path, got %q", err.Error())
 	}
 }
 

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -240,8 +240,7 @@ func TestGetFilesMissingPathWithoutMetaErrors(t *testing.T) {
 	cfg.PassedFiles = []string{"./does/not/exist.txt"}
 
 	// A path the user named explicitly, with no glob metacharacters, is a typo
-	// rather than a pattern that matched nothing, so it has to be an error.
-	// Previously it was passed on and silently dropped, and the run exited 0.
+	// rather than a pattern that matched nothing, so it is an error.
 	_, err := GetFiles(*cfg)
 	if err == nil {
 		t.Fatal("GetFiles(missing): expected an error for a path that does not exist, got nil")

--- a/pkg/files/files_test.go
+++ b/pkg/files/files_test.go
@@ -173,6 +173,12 @@ func TestAddToFiles(t *testing.T) {
 			*configuration,
 			[]string{"./files.go"},
 		},
+		{
+			[]string{},
+			"./does/not/exist.txt",
+			*configuration,
+			[]string{},
+		},
 	}
 
 	for _, tt := range addToFilesTests {
@@ -242,7 +248,7 @@ func TestGetFilesGlobWithoutMetaKeepsPath(t *testing.T) {
 	// call should not fail and should not invent matches.
 	for _, f := range files {
 		if f == "./does/not/exist.txt" {
-			return
+			t.Fatalf("GetFiles(missing): expected %q to be dropped, got: %v", "./does/not/exist.txt", files)
 		}
 	}
 }


### PR DESCRIPTION
## What's broken

Passing a path that does not exist panics the process.

```
$ ec nofile_does_not_exist_xyz.txt
Could not get the ContentType of file: nofile_does_not_exist_xyz.txt
stat nofile_does_not_exist_xyz.txt: no such file or directory
panic: open nofile_does_not_exist_xyz.txt: no such file or directory
    .../pkg/validation.ValidateFileWithDefinition(...) validation.go:72
```

## The fix

`AddToFiles` logs the `GetContentType` error and then appends the path anyway, because the skip is guarded by `err == nil`. `os.ReadFile` in the validator then panics on it.

It now returns early when the content type could not be read. The `err == nil` in the next condition becomes redundant and is dropped.

Nothing downstream wants the unreadable path: all three call sites only collect the returned slice, and its only consumer is `ValidateFileWithDefinition`, which is the panic site.

After:

```
$ ec nofile_does_not_exist_xyz.txt
Could not get the ContentType of file: nofile_does_not_exist_xyz.txt
stat nofile_does_not_exist_xyz.txt: no such file or directory
$ echo $?
0
```

## Verification

`TestGetFilesGlobWithoutMetaKeepsPath` already described this behaviour in a comment, "logs and drops them (they have no content type)", but its loop only returned when it found the path, so it passed either way and asserted nothing. It now fails if the path survives, which is what its comment always meant.

Added a nonexistent-path case to `TestAddToFiles` too. With the change reverted both fail, reporting the path present in the result. `go test ./...` passes.
