### PR TITLE
fix: correct the -disable-end-of-line flag description

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ OPTIONS:
   -disable-charset
         disables only the charset check
   -disable-end-of-line
-        disables the trailing whitespace check
+        disables the end-of-line check
   -disable-indent-size
         disables only the indent-size check
   -disable-indentation

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -82,7 +82,7 @@ func init() {
 	flag.BoolFunc("no-color", "disables printing color", enableNoColor)
 	flag.BoolFunc("color", "enables printing color", disableNoColor)
 	flag.BoolVar(&cmdlineConfig.Disable.TrimTrailingWhitespace, "disable-trim-trailing-whitespace", false, "disables the trailing whitespace check")
-	flag.BoolVar(&cmdlineConfig.Disable.EndOfLine, "disable-end-of-line", false, "disables the trailing whitespace check")
+	flag.BoolVar(&cmdlineConfig.Disable.EndOfLine, "disable-end-of-line", false, "disables the end-of-line check")
 	flag.BoolVar(&cmdlineConfig.Disable.InsertFinalNewline, "disable-insert-final-newline", false, "disables the final newline check")
 	flag.BoolVar(&cmdlineConfig.Disable.Indentation, "disable-indentation", false, "disables the indentation check")
 	flag.BoolVar(&cmdlineConfig.Disable.IndentSize, "disable-indent-size", false, "disables only the indent-size check")

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"os"
 	"runtime"
 	"strings"
@@ -227,6 +228,22 @@ func cdRelativeToRepo(t *testing.T, path string) {
 	t.Helper()
 	newdir := "../../" + path
 	t.Chdir(newdir)
+}
+
+// TestFlagDisableEndOfLineDescribesEndOfLine guards against the description for
+// -disable-end-of-line being copy-pasted from -disable-trim-trailing-whitespace,
+// which would leave the flag documented as disabling the wrong check.
+func TestFlagDisableEndOfLineDescribesEndOfLine(t *testing.T) {
+	f := flag.CommandLine.Lookup("disable-end-of-line")
+	if f == nil {
+		t.Fatal("expected a -disable-end-of-line flag to be registered")
+	}
+	if !strings.Contains(f.Usage, "end-of-line") {
+		t.Errorf("expected -disable-end-of-line's description to mention the end-of-line check, got %q", f.Usage)
+	}
+	if strings.Contains(f.Usage, "trailing whitespace") {
+		t.Errorf("-disable-end-of-line's description wrongly mentions the trailing whitespace check, got %q", f.Usage)
+	}
 }
 
 func TestReturnCodeInterface(t *testing.T) {

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"os"
 	"runtime"
 	"strings"
@@ -228,22 +227,6 @@ func cdRelativeToRepo(t *testing.T, path string) {
 	t.Helper()
 	newdir := "../../" + path
 	t.Chdir(newdir)
-}
-
-// TestFlagDisableEndOfLineDescribesEndOfLine guards against the description for
-// -disable-end-of-line being copy-pasted from -disable-trim-trailing-whitespace,
-// which would leave the flag documented as disabling the wrong check.
-func TestFlagDisableEndOfLineDescribesEndOfLine(t *testing.T) {
-	f := flag.CommandLine.Lookup("disable-end-of-line")
-	if f == nil {
-		t.Fatal("expected a -disable-end-of-line flag to be registered")
-	}
-	if !strings.Contains(f.Usage, "end-of-line") {
-		t.Errorf("expected -disable-end-of-line's description to mention the end-of-line check, got %q", f.Usage)
-	}
-	if strings.Contains(f.Usage, "trailing whitespace") {
-		t.Errorf("-disable-end-of-line's description wrongly mentions the trailing whitespace check, got %q", f.Usage)
-	}
 }
 
 func TestReturnCodeInterface(t *testing.T) {

--- a/docs/editorconfig-checker.1
+++ b/docs/editorconfig-checker.1
@@ -15,7 +15,7 @@ print debugging information
 .HP
 \fB\-disable\-end\-of\-line\fR
 .IP
-disables the trailing whitespace check
+disables the end\-of\-line check
 .HP
 \fB\-disable\-indent\-size\fR
 .IP


### PR DESCRIPTION
## What's broken

`-disable-end-of-line` documents itself as disabling a different check.

```
$ ec --help
  -disable-end-of-line
        disables the trailing whitespace check
```

That is the description of `-disable-trim-trailing-whitespace`, two entries below. The flag itself works correctly, only its description is wrong, so anyone reading `--help` to turn off the end-of-line check has no way to tell it is the right flag.

## The fix

One string in `cmd/editorconfig-checker/main.go`. The same wrong text is copied into `README.md` (the pasted `--help` output) and `docs/editorconfig-checker.1`, so both are corrected to match.

The man page is hand-maintained rather than generated, so it needed the same edit.

## Verification

A test that looks the flag up in `flag.CommandLine` and asserts its description mentions the end-of-line check and not trailing whitespace. With the old string restored it fails on both assertions. `go test ./...` passes.
