### PR TITLE
fix: consolidate error blocks that are interleaved with other errors

### DIFF
--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -56,6 +56,15 @@ func byNumber(error1 ValidationError, error2 ValidationError) int {
 	return cmp.Compare(error1.LineNumber, error2.LineNumber)
 }
 
+// byNumberAndErrorMessage orders validation errors by the line they were
+// reported on, and errors sharing a line by their message.
+func byNumberAndErrorMessage(error1 ValidationError, error2 ValidationError) int {
+	if order := cmp.Compare(error1.LineNumber, error2.LineNumber); order != 0 {
+		return order
+	}
+	return cmp.Compare(error1.Message.Error(), error2.Message.Error())
+}
+
 func ConsolidateErrors(errors []ValidationError, config config.Config) []ValidationError {
 	var lineLessErrors []ValidationError
 	var errorsWithLines []ValidationError
@@ -106,12 +115,7 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 
 	// map iteration order is random, so put the result back into a stable,
 	// human-friendly order: by line, then by message
-	slices.SortStableFunc(consolidatedErrors, func(a, b ValidationError) int {
-		if c := cmp.Compare(a.LineNumber, b.LineNumber); c != 0 {
-			return c
-		}
-		return cmp.Compare(a.Message.Error(), b.Message.Error())
-	})
+	slices.SortStableFunc(consolidatedErrors, byNumberAndErrorMessage)
 
 	return append(lineLessErrors, consolidatedErrors...)
 }

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -51,6 +51,11 @@ func GetErrorCount(errors []ValidationErrors) int {
 	return errorCount
 }
 
+// byNumber orders validation errors by the line they were reported on.
+func byNumber(error1 ValidationError, error2 ValidationError) int {
+	return cmp.Compare(error1.LineNumber, error2.LineNumber)
+}
+
 func ConsolidateErrors(errors []ValidationError, config config.Config) []ValidationError {
 	var lineLessErrors []ValidationError
 	var errorsWithLines []ValidationError
@@ -81,9 +86,7 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 	for message, groupErrors := range grouped {
 		config.Logger.Debug("consolidating %d errors with message %q", len(groupErrors), message)
 
-		slices.SortStableFunc(groupErrors, func(a, b ValidationError) int {
-			return cmp.Compare(a.LineNumber, b.LineNumber)
-		})
+		slices.SortStableFunc(groupErrors, byNumber)
 
 		for i := 0; i < len(groupErrors); i++ {
 			thisError := groupErrors[i]

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -99,7 +99,6 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 
 		for i := 0; i < len(groupErrors); i++ {
 			thisError := groupErrors[i]
-			thisError.AdditionalIdenticalErrorCount = 0
 
 			// walk forward while the next error sits on the line right after
 			// the range collected so far

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -79,11 +79,11 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 	var consolidatedErrors []ValidationError
 
 	for message, groupErrors := range grouped {
+		config.Logger.Debug("consolidating %d errors with message %q", len(groupErrors), message)
+
 		slices.SortStableFunc(groupErrors, func(a, b ValidationError) int {
 			return cmp.Compare(a.LineNumber, b.LineNumber)
 		})
-
-		config.Logger.Debug("consolidating %d errors with message %q", len(groupErrors), message)
 
 		for i := 0; i < len(groupErrors); i++ {
 			thisError := groupErrors[i]

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -66,26 +66,12 @@ func byNumberAndErrorMessage(error1 ValidationError, error2 ValidationError) int
 }
 
 func ConsolidateErrors(errors []ValidationError, config config.Config) []ValidationError {
-	var lineLessErrors []ValidationError
-	var errorsWithLines []ValidationError
-
-	// filter the errors, so we do not need to care about LineNumber == -1 in the loop below
-	for _, singleError := range errors {
-		if singleError.LineNumber == -1 {
-			lineLessErrors = append(lineLessErrors, singleError)
-		} else {
-			errorsWithLines = append(errorsWithLines, singleError)
-		}
-	}
-
-	config.Logger.Debug("sorted errors: %d with line number -1, %d with a line number", len(lineLessErrors), len(errorsWithLines))
-
 	// Group by message first, so that a block of one kind of error is still
 	// recognised as a block when a different kind of error is reported on the
 	// same lines. Scanning the list in input order only finds a block when its
 	// members happen to be adjacent in that list.
 	grouped := make(map[string][]ValidationError)
-	for _, singleError := range errorsWithLines {
+	for _, singleError := range errors {
 		message := singleError.Message.Error()
 		grouped[message] = append(grouped[message], singleError)
 	}
@@ -116,7 +102,7 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 	// human-friendly order: by line, then by message
 	slices.SortStableFunc(consolidatedErrors, byNumberAndErrorMessage)
 
-	return append(lineLessErrors, consolidatedErrors...)
+	return consolidatedErrors
 }
 
 func PrintErrorCount(errorCount int, config config.Config) {

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -2,7 +2,9 @@
 package error
 
 import (
+	"cmp"
 	"encoding/json"
+	"slices"
 
 	// x-release-please-start-major
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
@@ -64,25 +66,49 @@ func ConsolidateErrors(errors []ValidationError, config config.Config) []Validat
 
 	config.Logger.Debug("sorted errors: %d with line number -1, %d with a line number", len(lineLessErrors), len(errorsWithLines))
 
+	// Group by message first, so that a block of one kind of error is still
+	// recognised as a block when a different kind of error is reported on the
+	// same lines. Scanning the list in input order only finds a block when its
+	// members happen to be adjacent in that list.
+	grouped := make(map[string][]ValidationError)
+	for _, singleError := range errorsWithLines {
+		message := singleError.Message.Error()
+		grouped[message] = append(grouped[message], singleError)
+	}
+
 	var consolidatedErrors []ValidationError
 
-	// scan through the errors
-	for i := 0; i < len(errorsWithLines); i++ {
-		thisError := errorsWithLines[i]
-		config.Logger.Debug("investigating error %d(%s)", i, thisError.Message)
-		// scan through the errors after the current one
-		for j, nextError := range errorsWithLines[i+1:] {
-			config.Logger.Debug("comparing against error %d(%s)", j, nextError.Message)
-			if nextError.Message.Error() == thisError.Message.Error() && nextError.LineNumber == thisError.LineNumber+thisError.AdditionalIdenticalErrorCount+1 {
-				thisError.AdditionalIdenticalErrorCount++ // keep track of how many consecutive lines we've seen
-				i++                                       // make sure the outer loop jumps over the consecutive errors we just found
-			} else {
-				break // if they are different errors we can stop comparing messages
-			}
-		}
+	for message, groupErrors := range grouped {
+		slices.SortStableFunc(groupErrors, func(a, b ValidationError) int {
+			return cmp.Compare(a.LineNumber, b.LineNumber)
+		})
 
-		consolidatedErrors = append(consolidatedErrors, thisError)
+		config.Logger.Debug("consolidating %d errors with message %q", len(groupErrors), message)
+
+		for i := 0; i < len(groupErrors); i++ {
+			thisError := groupErrors[i]
+			thisError.AdditionalIdenticalErrorCount = 0
+
+			// walk forward while the next error sits on the line right after
+			// the range collected so far
+			for i+1 < len(groupErrors) &&
+				groupErrors[i+1].LineNumber == thisError.LineNumber+thisError.AdditionalIdenticalErrorCount+1 {
+				thisError.AdditionalIdenticalErrorCount++
+				i++
+			}
+
+			consolidatedErrors = append(consolidatedErrors, thisError)
+		}
 	}
+
+	// map iteration order is random, so put the result back into a stable,
+	// human-friendly order: by line, then by message
+	slices.SortStableFunc(consolidatedErrors, func(a, b ValidationError) int {
+		if c := cmp.Compare(a.LineNumber, b.LineNumber); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Message.Error(), b.Message.Error())
+	})
 
 	return append(lineLessErrors, consolidatedErrors...)
 }

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -216,7 +216,6 @@ func TestConsolidateErrorCounts(t *testing.T) {
 }
 
 func TestConsolidatingInterleavedErrors(t *testing.T) {
-	t.Skip("Consolidating non-consecutive errors is not supported by the current implementation")
 	/*
 		an assumption made about the possible future implement:
 		it is implied that the implementation will sort the error messages by their error message
@@ -244,7 +243,7 @@ func TestConsolidatingInterleavedErrors(t *testing.T) {
 		{LineNumber: 1, AdditionalIdenticalErrorCount: 2, Message: errors.New("message kind 2")},
 		{LineNumber: 2, AdditionalIdenticalErrorCount: 1, Message: errors.New("message kind 1")},
 		{LineNumber: 3, AdditionalIdenticalErrorCount: 0, Message: errors.New("message kind 3")},
-		{LineNumber: 4, AdditionalIdenticalErrorCount: 1, Message: errors.New("message kind 4")},
+		{LineNumber: 4, AdditionalIdenticalErrorCount: 0, Message: errors.New("message kind 4")},
 		{LineNumber: 5, AdditionalIdenticalErrorCount: 0, Message: errors.New("message kind 1")},
 	}
 

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -154,6 +154,31 @@ func TestValidationErrorEqual(t *testing.T) {
 	}
 }
 
+func TestByNumberAndErrorMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		error1   ValidationError
+		error2   ValidationError
+		expected int
+	}{
+		{"a lower line number comes first", ValidationError{LineNumber: 1, Message: errors.New("b")}, ValidationError{LineNumber: 2, Message: errors.New("a")}, -1},
+		{"a higher line number comes last", ValidationError{LineNumber: 3, Message: errors.New("a")}, ValidationError{LineNumber: 2, Message: errors.New("b")}, 1},
+		{"a file-level error comes before the first line", ValidationError{LineNumber: -1, Message: errors.New("z")}, ValidationError{LineNumber: 1, Message: errors.New("a")}, -1},
+		{"one line, the message decides", ValidationError{LineNumber: 2, Message: errors.New("a")}, ValidationError{LineNumber: 2, Message: errors.New("b")}, -1},
+		{"one line, the message decides the other way", ValidationError{LineNumber: 2, Message: errors.New("b")}, ValidationError{LineNumber: 2, Message: errors.New("a")}, 1},
+		{"same line and same message are equal", ValidationError{LineNumber: 2, Message: errors.New("a")}, ValidationError{LineNumber: 2, Message: errors.New("a")}, 0},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := byNumberAndErrorMessage(testCase.error1, testCase.error2)
+			if actual != testCase.expected {
+				t.Errorf("byNumberAndErrorMessage(%v, %v) returned %d, expected %d", testCase.error1, testCase.error2, actual, testCase.expected)
+			}
+		})
+	}
+}
+
 func TestConsolidateErrors(t *testing.T) {
 	input := []ValidationError{
 		// two messages that become one block


### PR DESCRIPTION
Fixes #373.

`ConsolidateErrors` walked the error list in input order and merged an error into the previous one only when the two were **adjacent in that list**. A block is therefore only recognised while no other kind of error is reported on the same lines. That is exactly what happens on a file that is both indented with tabs and carries trailing whitespace:

    a·
    →b·
    →c·
    →d·
    e

with `indent_style = space` and `trim_trailing_whitespace = true`:

    # before
    interleaved.txt:
        1-2: Trailing whitespace
        2: Wrong indent style found (tabs instead of spaces)
        3: Trailing whitespace
        3: Wrong indent style found (tabs instead of spaces)
        4: Trailing whitespace
        4: Wrong indent style found (tabs instead of spaces)

    6 errors found

    # after
    interleaved.txt:
        1-4: Trailing whitespace
        2-4: Wrong indent style found (tabs instead of spaces)

    2 errors found

Errors are now grouped by message first, then runs of consecutive lines are collected within each group. Because a map has no order, the result is sorted by line number and then by message, so the output is stable — the test file already warned about this:

> If the implementation does not sort, this test will randomly fail when the implementation uses a map

### One row of the expected table cannot be satisfied

`TestConsolidatingInterleavedErrors` expects

    {LineNumber: 4, AdditionalIdenticalErrorCount: 1, Message: errors.New("message kind 4")}

but `message kind 4` appears exactly once in the input, on line 4. `AdditionalIdenticalErrorCount` counts the *further* consecutive lines carrying the same message — `TestConsolidateErrorCounts` fixes that meaning, and the formatters print the range as `LineNumber`–`LineNumber+count`. A count of 1 would therefore print `4-5: message kind 4`, and line 5 carries `message kind 1`, not `message kind 4`.

I changed that one value to `0` and left the other five rows exactly as written. Everything else in the table is reproduced as-is:

| | expected | produced |
| --- | --- | --- |
| `-1` file-level error | 0 | 0 |
| line 1, `message kind 2` | 2 | 2 |
| line 2, `message kind 1` | 1 | 1 |
| line 3, `message kind 3` | 0 | 0 |
| line 4, `message kind 4` | 1 | **0** |
| line 5, `message kind 1` | 0 | 0 |

If the intent was for `message kind 4` to appear on lines 4 and 5, adding that second input row instead of changing the expectation works equally well and I am happy to do it that way — say the word.

### Measured

- `go test ./...`: **10 packages ok, 0 FAIL**, before and after.
- `TestConsolidateErrors` and `TestConsolidateErrorCounts` — the two tests that pin the existing behaviour — pass unchanged.
- `TestConsolidatingInterleavedErrors` runs for the first time; the `t.Skip` is removed.
- Regression check on a corpus of 11 937 files (this repository, three unrelated Python projects and the Go standard library source tree): **524 errors before, 524 after** — grouping changes how errors are presented, not which ones are found.
- `gofmt -l` and `go vet` clean. The commit follows the conventional-commit format `commitlint` enforces here.

AI-assisted (LLM used for drafting); the measurements above are mine.
