### PR TITLE
feat!: remove support for the deprecated `.ecrc` config file name

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -21,9 +21,6 @@ indent_size = unset
 [*.nix]
 indent_size = 2
 
-[.ecrc]
-indent_size = 2
-
 [Makefile]
 indent_style = tab
 indent_size = unset

--- a/README.md
+++ b/README.md
@@ -242,10 +242,7 @@ The following output formats are supported:
 
 ## Configuration
 
-The configuration is done via arguments or it will take the first config file found with the following file names:
-
-- `.editorconfig-checker.json`
-- `.ecrc` (deprecated filename, soon unsupported)
+The configuration is done via arguments or it will take the config file named `.editorconfig-checker.json`.
 
 A sample configuration file can look like this and will be used from your current working directory if not specified via the `--config` argument:
 

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"runtime/pprof"
 	"strconv"
-	"strings"
 
 	// x-release-please-start-major
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
@@ -25,7 +24,7 @@ import (
 var version string = "v3.11.1" // x-release-please-version
 
 // defaultConfigFileNames determines the file names where the config is located
-var defaultConfigFileNames = []string{".editorconfig-checker.json", ".ecrc"}
+var defaultConfigFileNames = []string{".editorconfig-checker.json"}
 
 // currentConfig is the config used in this run
 var currentConfig *config.Config
@@ -126,10 +125,6 @@ func parseArguments() {
 	loggerInjectionHook()
 
 	currentConfig.Logger.NoColor = cmdlineConfig.NoColor
-
-	if strings.HasSuffix(currentConfig.Path, ".ecrc") {
-		currentConfig.Logger.Warning("The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead. You can simply rename it")
-	}
 
 	if writeConfigFile {
 		err := currentConfig.Save(version)

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -97,50 +97,6 @@ func TestMainLoadingAncientConfig(t *testing.T) {
 	}
 }
 
-func TestMainWithEcrc(t *testing.T) {
-	// feed a symlink named .ecrc pointing to our actual .editorconfig-checker.json
-	output, lastSeenCode := runWithArguments(t, "--config", "testdata/.ecrc")
-	if lastSeenCode != exitCodeNormal {
-		t.Errorf("main exited with return code %d, but we expected %d", lastSeenCode, exitCodeNormal)
-		t.Logf("Output:\n%s", output)
-	}
-	if !strings.Contains(output, "`.ecrc` is deprecated") {
-		t.Error("main did not produce a warning that .ecrc is deprecated despite being give a file named .ecrc.")
-		t.Logf("Output:\n%s", output)
-	}
-}
-
-func TestMainEcrcDeprecationWarningHonorsNoColor(t *testing.T) {
-	output, lastSeenCode := runWithArguments(t, "--no-color", "--config", "testdata/.ecrc")
-	if lastSeenCode != exitCodeNormal {
-		t.Errorf("main exited with return code %d, but we expected %d", lastSeenCode, exitCodeNormal)
-		t.Logf("Output:\n%s", output)
-	}
-	if !strings.Contains(output, "`.ecrc` is deprecated") {
-		t.Error("main did not produce a warning that .ecrc is deprecated despite being given a file named .ecrc.")
-		t.Logf("Output:\n%s", output)
-	}
-	if strings.Contains(output, "\x1b[") {
-		t.Errorf("main produced ANSI color escape codes despite --no-color being set\nOutput:\n%q", output)
-	}
-}
-
-func TestMainEcrcDeprecationWarningHonorsNoColorEnvVar(t *testing.T) {
-	t.Setenv("NO_COLOR", "1")
-	output, lastSeenCode := runWithArguments(t, "--config", "testdata/.ecrc")
-	if lastSeenCode != exitCodeNormal {
-		t.Errorf("main exited with return code %d, but we expected %d", lastSeenCode, exitCodeNormal)
-		t.Logf("Output:\n%s", output)
-	}
-	if !strings.Contains(output, "`.ecrc` is deprecated") {
-		t.Error("main did not produce a warning that .ecrc is deprecated despite being given a file named .ecrc.")
-		t.Logf("Output:\n%s", output)
-	}
-	if strings.Contains(output, "\x1b[") {
-		t.Errorf("main produced ANSI color escape codes despite NO_COLOR being set\nOutput:\n%q", output)
-	}
-}
-
 func TestMainShowVersion(t *testing.T) {
 	output, lastSeenCode := runWithArguments(t, "--version")
 	if lastSeenCode != exitCodeNormal {

--- a/cmd/editorconfig-checker/testdata/.ecrc
+++ b/cmd/editorconfig-checker/testdata/.ecrc
@@ -1,1 +1,0 @@
-../../../.editorconfig-checker.json


### PR DESCRIPTION
Ref #390

___

The `.ecrc` config file name has been deprecated since v3.3.0, where loading it started emitting a warning (#389).

BREAKING CHANGE: `.ecrc` is no longer discovered as a default config file name. Rename `.ecrc` to `.editorconfig-checker.json`, or pass the file explicitly with `--config .ecrc`.