### PR TITLE
fix!: typo in config, `SpacesAftertabs` => `SpacesAfterTabs`

### DIFF
--- a/.editorconfig-checker.schema.json
+++ b/.editorconfig-checker.schema.json
@@ -46,11 +46,6 @@
             "default": false,
             "description": "Allow spaces after tabs in indentation (mixed indentation). When `false`, spaces following tabs are flagged as errors"
         },
-        "SpacesAftertabs": {
-            "type": "boolean",
-            "deprecated": true,
-            "description": "The configuration key `SpacesAftertabs` is deprecated. Use `SpacesAfterTabs` instead"
-        },
         "NoColor": {
             "type": "boolean",
             "default": false,

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -91,8 +91,8 @@ func TestMainLoadingAncientConfig(t *testing.T) {
 		t.Errorf("main exited with return code %d, but we expected %d", lastSeenCode, exitCodeErrorOccurred)
 		t.Logf("Output:\n%s", output)
 	}
-	if !strings.Contains(output, "SpacesAftertabs") {
-		t.Errorf("main did not produce a warning that SpacesAftertabs is deprecated\nOutput:\n%s", output)
+	if !strings.Contains(output, "Version from config file is not the same as the version of the binary") {
+		t.Errorf("main did not report the config file version mismatch\nOutput:\n%s", output)
 		t.Logf("Output:\n%s", output)
 	}
 }

--- a/cmd/editorconfig-checker/testdata/ancient-config.json
+++ b/cmd/editorconfig-checker/testdata/ancient-config.json
@@ -3,7 +3,7 @@
   "Verbose": false,
   "Debug": false,
   "IgnoreDefaults": false,
-  "SpacesAftertabs": false,
+  "SpacesAfterTabs": false,
   "NoColor": false,
   "Exclude": [],
   "AllowedContentTypes": [],

--- a/pkg/config/__snapshots__/config_test.snap
+++ b/pkg/config/__snapshots__/config_test.snap
@@ -45,7 +45,6 @@
  "Path": "../../.editorconfig-checker.json",
  "ShowVersion": false,
  "SpacesAfterTabs": false,
- "SpacesAftertabs": null,
  "Verbose": false,
  "Version": ""
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -136,7 +136,6 @@ type Config struct {
 	Format              outputformat.OutputFormat
 	Debug               bool
 	IgnoreDefaults      bool
-	SpacesAftertabs     *bool
 	SpacesAfterTabs     bool
 	NoColor             bool
 	Exclude             []string
@@ -250,12 +249,6 @@ func (c *Config) Merge(config Config) {
 
 	if config.IgnoreDefaults {
 		c.IgnoreDefaults = config.IgnoreDefaults
-	}
-
-	if config.SpacesAftertabs != nil {
-		c.Logger.Warning("The configuration key `SpacesAftertabs` is deprecated. Use `SpacesAfterTabs` instead.")
-
-		c.SpacesAfterTabs = *config.SpacesAftertabs
 	}
 
 	if config.SpacesAfterTabs {


### PR DESCRIPTION
Ref: #390

___

The deprecated `SpacesAftertabs` configuration key, along with its deprecation warning (#386), is no longer part of the config struct or the JSON schema.

BREAKING CHANGE: the deprecated `SpacesAftertabs` configuration key has been removed, use `SpacesAfterTabs` instead.