### PR TITLE
chore: disable commitlint footer-max-line-length rule

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,5 +2,6 @@ module.exports = {
     extends: ["@commitlint/config-conventional"],
     rules: {
         "body-max-line-length": [0, "never", []],
+        "footer-max-line-length": [0, "never", []],
     },
 };


### PR DESCRIPTION
Same reasoning as to why `body-max-line-length` is disabled, I think we should also disable the `footer-max-line-length` rule for commit message.

The goal of git commit message is to describe and have context of why the changes were made, restricting it makes it harder to describe.

Opened this PR because my PRs #603 and #604 started failing CI because of commitlint.