### PR TITLE
chore: match Go files by glob in release-please extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,16 +16,11 @@
                 "README.md",
                 "go.mod",
                 "default.nix",
-                "cmd/editorconfig-checker/main.go",
-                "pkg/config/config.go",
-                "pkg/config/config_test.go",
-                "pkg/error/error.go",
-                "pkg/error/error_test.go",
-                "pkg/files/files.go",
-                "pkg/validation/validation.go",
-                "pkg/validation/validation_test.go",
-                "pkg/validation/validators/validators.go",
-                "pkg/validation/validators/validators_test.go"
+                {
+                    "type": "generic",
+                    "path": "**/*.go",
+                    "glob": true
+                }
             ]
         }
     }


### PR DESCRIPTION
## Problem

The 4.0.0 release PR (#595) fails CI:

```
pkg/files/files_test.go:15:2: no required module provides package
github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config
```

`pkg/files/files_test.go` was missing from `extra-files` in `release-please-config.json`.

(still using "v3" path instead of v4)

## Fix

Rather than just adding the missing line, I thought it would be a good idea to replace by a single glob to avoid further mistakes.

## Note for after this merges

This fixes future releases but does not repair #595, since that branch already has the bad v3 line committed.

The `release-please--branches--main` branch should be deleted after this lands so the release PR is regenerated from scratch.
