### PR TITLE
fix: add missing space in wrong indentation type error message

### DIFF
--- a/pkg/validation/validators/validators.go
+++ b/pkg/validation/validators/validators.go
@@ -79,7 +79,7 @@ func Tab(line string, config config.Config) error {
 		matched := re.MatchString(line)
 
 		if !matched {
-			return errors.New("Wrong indentation type(spaces instead of tabs)")
+			return errors.New("Wrong indentation type (spaces instead of tabs)")
 		}
 
 	}

--- a/pkg/validation/validators/validators_test.go
+++ b/pkg/validation/validators/validators_test.go
@@ -148,7 +148,7 @@ func TestIndentation(t *testing.T) {
 		{"    x", "space", 4, nil},
 		{"   x", "space", 4, errors.New("Wrong amount of left-padding spaces(want multiple of 4)")},
 		{"	x", "tab", 0, nil},
-		{"   x", "tab", 0, errors.New("Wrong indentation type(spaces instead of tabs)")},
+		{"   x", "tab", 0, errors.New("Wrong indentation type (spaces instead of tabs)")},
 		{"	x", "x", 0, nil},
 		{"   x", "x", 0, nil},
 	}
@@ -222,7 +222,7 @@ func TestTab(t *testing.T) {
 		{"	x", spacesForbidden, nil},
 		{"	", spacesForbidden, nil},
 		{"		x", spacesForbidden, nil},
-		{"  	a", spacesForbidden, errors.New("Wrong indentation type(spaces instead of tabs)")},
+		{"  	a", spacesForbidden, errors.New("Wrong indentation type (spaces instead of tabs)")},
 		{" *", spacesForbidden, nil},
 		{"	 *", spacesForbidden, nil},
 		{"	 * some comment", spacesForbidden, nil},


### PR DESCRIPTION
I know it is really a small thing :sweat_smile: 

I never noticed it, even after years of using editorconfig-checker, but noticed it randomly when I did the screenshot for the new binary name: https://github.com/editorconfig-checker/editorconfig-checker/pull/371#issuecomment-5324782757

"Wrong indentation type(spaces instead of tabs)" message was missing a space before the parenthesis.

=> "Wrong indentation type (spaces instead of tabs)"