### PR TITLE
feat: add safe EditorConfig autofixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ OPTIONS:
         a regex which files should be excluded from checking - needs to be a valid regular expression. Combine patterns with | (pipe): -exclude "vendor|testdata"
   -f value
         specify the output format: default, codeclimate, gcc, github-actions (default default)
+  -fix
+        fix supported EditorConfig violations before checking
   -format value
         specify the output format: default, codeclimate, gcc, github-actions (default default)
   -h  print the help
@@ -207,6 +209,25 @@ OPTIONS:
 If you run this tool from a repository root it will check all files which are added to the git repository and are text files. If the tool isn't able to determine a file type it will be added to be checked too.
 
 If you run this tool from a normal directory it will check all files which are text files. If the tool isn't able to determine a file type it will be added to be checked too.
+
+### Fixing files
+
+Use `--fix` to apply the safe fixes supported by
+editorconfig-checker before it checks the files. The fix mode currently supports
+only these rules:
+
+- `trim_trailing_whitespace = true`
+- `end_of_line = lf`, `cr`, or `crlf`
+- `insert_final_newline = true` or `false`
+
+Indentation, `indent_size`, `max_line_length`, and `charset` violations remain
+check-only. All non-UTF-8, invalid UTF-8, and binary-like files are skipped, as
+are symbolic links and empty files. Inline disable directives are honored for
+trailing whitespace, and files with `editorconfig-checker-disable-file` are
+skipped. A second `--fix` run is idempotent. Changes are written through a
+same-directory temporary file and replacement; this is crash-resistant and
+atomic only where the operating system and filesystem provide those guarantees.
+Replacing a path does not update other hard links to the original file.
 
 ### Formats
 

--- a/cmd/editorconfig-checker/main.go
+++ b/cmd/editorconfig-checker/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
 	eccerror "github.com/editorconfig-checker/editorconfig-checker/v3/pkg/error"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/files"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/fix"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/outputformat"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/utils"
 	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/validation"
@@ -79,6 +80,7 @@ func init() {
 	flag.StringVar(&cmdlineExclude, "exclude", "", "a regex which files should be excluded from checking - needs to be a valid regular expression. Combine patterns with | (pipe): -exclude \"vendor|testdata\"")
 	flag.BoolVar(&cmdlineConfig.IgnoreDefaults, "ignore-defaults", false, "ignore default excludes")
 	flag.BoolVar(&cmdlineConfig.DryRun, "dry-run", false, "show which files would be checked")
+	flag.BoolVar(&cmdlineConfig.Fix, "fix", false, "fix supported EditorConfig violations before checking")
 	flag.BoolVar(&cmdlineConfig.ShowVersion, "version", false, "print the version number")
 	flag.BoolVar(&cmdlineConfig.Help, "help", false, "print the help")
 	flag.BoolVar(&cmdlineConfig.Help, "h", false, "print the help")
@@ -238,6 +240,28 @@ func main() {
 		}
 
 		exitProxy(exitCodeNormal)
+	}
+
+	if config.Fix {
+		for _, filePath := range filePaths {
+			lock := config.EditorconfigConfig
+			def, warnings, err := lock.LoadGraceful(filePath)
+			if err != nil {
+				config.Logger.Error("cannot load %s as .editorconfig: %s", filePath, err)
+				exitProxy(exitCodeErrorOccurred)
+			}
+			if warnings != nil {
+				config.Logger.Warning("%v", warnings.Error())
+			}
+			changed, err := fix.FixFile(filePath, config, def)
+			if err != nil {
+				config.Logger.Error("cannot fix %s: %s", filePath, err)
+				exitProxy(exitCodeErrorOccurred)
+			}
+			if changed {
+				config.Logger.Verbose("Fixed %s", filePath)
+			}
+		}
 	}
 
 	errors := validation.ProcessValidation(filePaths, config)

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -154,6 +154,25 @@ func TestMainFixReportsEditorconfigError(t *testing.T) {
 	}
 }
 
+func TestMainFixReportsEditorconfigWarning(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte("[*]\ntrim_trailing_whitespace = maybe\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("value  \n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	output, code := runWithArguments(t, "--fix", path)
+	if code != exitCodeNormal {
+		t.Fatalf("fix command exited with %d, output: %s", code, output)
+	}
+	if !strings.Contains(output, "not an acceptable value") {
+		t.Fatalf("fix command did not report editorconfig warning: %s", output)
+	}
+}
+
 func TestMainInitializingANewConfig(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -89,9 +89,12 @@ func TestMainFixesFilesBeforeChecking(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(oldDir) })
-	_, code := runWithArguments(t, "--fix", path)
+	output, code := runWithArguments(t, "--fix", "--verbose", path)
 	if code != exitCodeNormal {
 		t.Fatalf("fix command exited with %d", code)
+	}
+	if !strings.Contains(output, "Fixed") {
+		t.Fatalf("verbose fix output did not report the changed file: %s", output)
 	}
 	got, err := os.ReadFile(path)
 	if err != nil {
@@ -129,6 +132,25 @@ func TestMainFixWithEndOfLineDisabledStillChecksFinalNewline(t *testing.T) {
 	}
 	if string(got) != "value\r\n" {
 		t.Fatalf("got %q, want original CRLF content", got)
+	}
+}
+
+func TestMainFixReportsEditorconfigError(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte("[*\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("value  "), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	output, code := runWithArguments(t, "--fix", path)
+	if code != exitCodeErrorOccurred {
+		t.Fatalf("fix command exited with %d, output: %s", code, output)
+	}
+	if !strings.Contains(output, "cannot load") {
+		t.Fatalf("fix command did not report editorconfig load failure: %s", output)
 	}
 }
 

--- a/cmd/editorconfig-checker/main_test.go
+++ b/cmd/editorconfig-checker/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -68,6 +69,66 @@ func TestMainWithFilesGiven(t *testing.T) {
 	if lastSeenCode != exitCodeNormal {
 		t.Errorf("main exited with return code %d, but we expected %d", lastSeenCode, exitCodeNormal)
 		t.Logf("Output:\n%s", output)
+	}
+}
+
+func TestMainFixesFilesBeforeChecking(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte("[*]\ntrim_trailing_whitespace = true\ninsert_final_newline = true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("value  "), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	_, code := runWithArguments(t, "--fix", path)
+	if code != exitCodeNormal {
+		t.Fatalf("fix command exited with %d", code)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "value\n" {
+		t.Fatalf("got %q, want %q", got, "value\\n")
+	}
+}
+
+func TestMainFixWithEndOfLineDisabledStillChecksFinalNewline(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".editorconfig"), []byte("[*]\nend_of_line = lf\ninsert_final_newline = true\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("value\r\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldDir) })
+	_, code := runWithArguments(t, "--fix", "--disable-end-of-line", path)
+	if code != exitCodeNormal {
+		t.Fatalf("fix command exited with %d for a file whose final newline is valid", code)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "value\r\n" {
+		t.Fatalf("got %q, want original CRLF content", got)
 	}
 }
 

--- a/pkg/config/__snapshots__/config_test.snap
+++ b/pkg/config/__snapshots__/config_test.snap
@@ -32,6 +32,7 @@
   "testfiles",
   "testdata"
  ],
+ "Fix": false,
  "Format": "default",
  "Help": false,
  "IgnoreDefaults": false,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -128,7 +128,7 @@ type Config struct {
 	ShowVersion bool
 	Help        bool
 	DryRun      bool
-	Fix         bool `json:"-"`
+	Fix         bool
 	Path        string
 
 	// CONFIG FILE

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -128,6 +128,7 @@ type Config struct {
 	ShowVersion bool
 	Help        bool
 	DryRun      bool
+	Fix         bool `json:"-"`
 	Path        string
 
 	// CONFIG FILE
@@ -217,6 +218,10 @@ func (c *Config) Parse() error {
 func (c *Config) Merge(config Config) {
 	if config.DryRun {
 		c.DryRun = config.DryRun
+	}
+
+	if config.Fix {
+		c.Fix = config.Fix
 	}
 
 	if config.ShowVersion {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -120,6 +120,7 @@ func TestMerge(t *testing.T) {
 		Version:             "v3.11.1", // x-release-please-version
 		Help:                true,
 		DryRun:              true,
+		Fix:                 true,
 		Path:                "some-other",
 		Verbose:             true,
 		Format:              "default",

--- a/pkg/fix/fix.go
+++ b/pkg/fix/fix.go
@@ -21,77 +21,84 @@ import (
 // not modified: rewriting those files without an encoding-aware encoder could
 // corrupt their contents.
 func FixFile(filePath string, cfg config.Config, def *editorconfig.Definition) (bool, error) {
+	info, content, ok, err := readFixableFile(filePath, cfg)
+	if err != nil || !ok {
+		return false, err
+	}
+	fixed, changed := fixContent(content, cfg, def)
+	if !changed {
+		return false, nil
+	}
+	if err := atomicWrite(filePath, fixed, fileMode(info), info); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func readFixableFile(filePath string, cfg config.Config) (os.FileInfo, []byte, bool, error) {
 	info, err := os.Lstat(filePath)
 	if err != nil {
-		return false, err
+		return nil, nil, false, err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		verbose(&cfg, "Skipping %s: symbolic links are not modified", filePath)
-		return false, nil
+		return info, nil, false, nil
 	}
 	if !info.Mode().IsRegular() {
 		verbose(&cfg, "Skipping %s: not a regular file", filePath)
-		return false, nil
+		return info, nil, false, nil
 	}
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return false, err
+		return info, nil, false, err
 	}
 	// Empty files are intentionally left alone. The validation pipeline treats
 	// them as having no lines, regardless of insert_final_newline.
 	if len(content) == 0 {
-		return false, nil
+		return info, nil, false, nil
 	}
 	if bytes.Contains(content, []byte("\x00")) {
 		verbose(&cfg, "Skipping %s: binary-like content", filePath)
-		return false, nil
+		return info, nil, false, nil
 	}
 	if hasDisableFile(content) {
-		return false, nil
+		return info, nil, false, nil
 	}
 	encodingName, _, _ := encoding.Detect(content)
-	normalizedEncoding := strings.ToLower(strings.NewReplacer("-", "", "_", "").Replace(encodingName))
-	if normalizedEncoding != "" && normalizedEncoding != "unknown" && normalizedEncoding != "ascii" && normalizedEncoding != "utf8" && normalizedEncoding != "utf8sig" && normalizedEncoding != "utf8bom" {
+	if !isSupportedEncoding(encodingName) {
 		verbose(&cfg, "Skipping %s: unsupported encoding %s", filePath, encodingName)
-		return false, nil
+		return info, nil, false, nil
 	}
 	if !utf8.Valid(content) {
 		verbose(&cfg, "Skipping %s: content is not valid UTF-8", filePath)
-		return false, nil
+		return info, nil, false, nil
 	}
+	return info, content, true, nil
+}
 
-	original := content
+func isSupportedEncoding(name string) bool {
+	normalized := strings.ToLower(strings.NewReplacer("-", "", "_", "").Replace(name))
+	return normalized == "" || normalized == "unknown" || normalized == "ascii" ||
+		normalized == "utf8" || normalized == "utf8sig" || normalized == "utf8bom"
+}
+
+func fixContent(original []byte, cfg config.Config, def *editorconfig.Definition) ([]byte, bool) {
 	bom := []byte(nil)
+	content := original
 	if bytes.HasPrefix(content, []byte{0xef, 0xbb, 0xbf}) {
 		bom, content = append([]byte(nil), content[:3]...), content[3:]
 	}
 
-	endOfLine := strings.ToLower(def.Raw["end_of_line"])
-	if endOfLine == "unset" {
-		endOfLine = ""
-	}
-	desiredEOL := ""
-	switch endOfLine {
-	case "lf":
-		desiredEOL = "\n"
-	case "cr":
-		desiredEOL = "\r"
-	case "crlf":
-		desiredEOL = "\r\n"
-	case "":
-	default:
+	desiredEOL, valid := configuredEOL(def.Raw["end_of_line"])
+	if !valid {
 		// Unknown values are reported by validation; never guess a rewrite.
-		return false, nil
+		return original, false
 	}
-
+	insert, valid := configuredFinalNewline(def.Raw["insert_final_newline"])
+	if !valid {
+		return original, false
+	}
 	trim := def.Raw["trim_trailing_whitespace"] == "true" && !cfg.Disable.TrimTrailingWhitespace
-	insert := strings.ToLower(def.Raw["insert_final_newline"])
-	if insert == "unset" {
-		insert = ""
-	}
-	if insert != "" && insert != "true" && insert != "false" {
-		return false, nil
-	}
 	if cfg.Disable.EndOfLine {
 		desiredEOL = ""
 	}
@@ -99,10 +106,42 @@ func FixFile(filePath string, cfg config.Config, def *editorconfig.Definition) (
 		insert = ""
 	}
 	if !trim && desiredEOL == "" && insert == "" {
-		return false, nil
+		return original, false
 	}
 
-	parts := splitLines(content)
+	fixed := fixLines(splitLines(content), trim, desiredEOL)
+	fixed = fixFinalNewline(fixed, insert, desiredEOL)
+	fixed = append(bom, fixed...)
+	return fixed, !bytes.Equal(original, fixed)
+}
+
+func configuredEOL(raw string) (string, bool) {
+	switch value := strings.ToLower(raw); value {
+	case "", "unset":
+		return "", true
+	case "lf":
+		return "\n", true
+	case "cr":
+		return "\r", true
+	case "crlf":
+		return "\r\n", true
+	default:
+		return "", false
+	}
+}
+
+func configuredFinalNewline(raw string) (string, bool) {
+	switch value := strings.ToLower(raw); value {
+	case "", "unset":
+		return "", true
+	case "true", "false":
+		return value, true
+	default:
+		return "", false
+	}
+}
+
+func fixLines(parts []linePart, trim bool, desiredEOL string) []byte {
 	var out bytes.Buffer
 	for _, part := range parts {
 		line := part.text
@@ -116,39 +155,33 @@ func FixFile(filePath string, cfg config.Config, def *editorconfig.Definition) (
 		out.Write(line)
 		out.Write(terminator)
 	}
-	fixed := out.Bytes()
+	return out.Bytes()
+}
 
+func fixFinalNewline(content []byte, insert, desiredEOL string) []byte {
 	if insert == "true" {
 		eol := desiredEOL
 		if eol == "" {
-			eol = detectFinalEOL(fixed)
+			eol = detectFinalEOL(content)
 			if eol == "" {
 				eol = "\n"
 			}
 		}
-		if !bytes.HasSuffix(fixed, []byte(eol)) {
-			fixed = append(fixed, eol...)
+		if !bytes.HasSuffix(content, []byte(eol)) {
+			content = append(content, eol...)
 		}
 	} else if insert == "false" {
-		for len(fixed) > 0 {
-			if bytes.HasSuffix(fixed, []byte("\r\n")) {
-				fixed = fixed[:len(fixed)-2]
-			} else if fixed[len(fixed)-1] == '\r' || fixed[len(fixed)-1] == '\n' {
-				fixed = fixed[:len(fixed)-1]
+		for len(content) > 0 {
+			if bytes.HasSuffix(content, []byte("\r\n")) {
+				content = content[:len(content)-2]
+			} else if content[len(content)-1] == '\r' || content[len(content)-1] == '\n' {
+				content = content[:len(content)-1]
 			} else {
 				break
 			}
 		}
 	}
-
-	fixed = append(bom, fixed...)
-	if bytes.Equal(original, fixed) {
-		return false, nil
-	}
-	if err := atomicWrite(filePath, fixed, fileMode(info), info); err != nil {
-		return false, err
-	}
-	return true, nil
+	return content
 }
 
 func verbose(cfg *config.Config, format string, args ...any) {

--- a/pkg/fix/fix.go
+++ b/pkg/fix/fix.go
@@ -64,13 +64,13 @@ func readFixableFile(filePath string, cfg config.Config) (os.FileInfo, []byte, b
 	if hasDisableFile(content) {
 		return info, nil, false, nil
 	}
+	if !utf8.Valid(content) {
+		verbose(&cfg, "Skipping %s: content is not valid UTF-8", filePath)
+		return info, nil, false, nil
+	}
 	encodingName, _, _ := encoding.Detect(content)
 	if !isSupportedEncoding(encodingName) {
 		verbose(&cfg, "Skipping %s: unsupported encoding %s", filePath, encodingName)
-		return info, nil, false, nil
-	}
-	if !utf8.Valid(content) {
-		verbose(&cfg, "Skipping %s: content is not valid UTF-8", filePath)
 		return info, nil, false, nil
 	}
 	return info, content, true, nil
@@ -247,11 +247,7 @@ func fileMode(info os.FileInfo) os.FileMode {
 }
 
 func splitPath(path string) (string, string) {
-	dir := filepath.Dir(path)
-	if dir == "" {
-		dir = "."
-	}
-	return dir, filepath.Base(path)
+	return filepath.Dir(path), filepath.Base(path)
 }
 
 type linePart struct {

--- a/pkg/fix/fix.go
+++ b/pkg/fix/fix.go
@@ -1,0 +1,302 @@
+// Package fix provides safe fixes for a subset of EditorConfig rules.
+package fix
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"unicode/utf8"
+
+	editorconfig "github.com/editorconfig/editorconfig-core-go/v2"
+
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/encoding"
+)
+
+// FixFile applies the safe, supported fixes for filePath. It returns true when
+// the file was changed. Rules which are not explicitly supported remain check-only.
+// Files which are not valid UTF-8 (including binary-like files) are deliberately
+// not modified: rewriting those files without an encoding-aware encoder could
+// corrupt their contents.
+func FixFile(filePath string, cfg config.Config, def *editorconfig.Definition) (bool, error) {
+	info, err := os.Lstat(filePath)
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		verbose(&cfg, "Skipping %s: symbolic links are not modified", filePath)
+		return false, nil
+	}
+	if !info.Mode().IsRegular() {
+		verbose(&cfg, "Skipping %s: not a regular file", filePath)
+		return false, nil
+	}
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return false, err
+	}
+	// Empty files are intentionally left alone. The validation pipeline treats
+	// them as having no lines, regardless of insert_final_newline.
+	if len(content) == 0 {
+		return false, nil
+	}
+	if bytes.Contains(content, []byte("\x00")) {
+		verbose(&cfg, "Skipping %s: binary-like content", filePath)
+		return false, nil
+	}
+	if hasDisableFile(content) {
+		return false, nil
+	}
+	encodingName, _, _ := encoding.Detect(content)
+	normalizedEncoding := strings.ToLower(strings.NewReplacer("-", "", "_", "").Replace(encodingName))
+	if normalizedEncoding != "" && normalizedEncoding != "unknown" && normalizedEncoding != "ascii" && normalizedEncoding != "utf8" && normalizedEncoding != "utf8sig" && normalizedEncoding != "utf8bom" {
+		verbose(&cfg, "Skipping %s: unsupported encoding %s", filePath, encodingName)
+		return false, nil
+	}
+	if !utf8.Valid(content) {
+		verbose(&cfg, "Skipping %s: content is not valid UTF-8", filePath)
+		return false, nil
+	}
+
+	original := content
+	bom := []byte(nil)
+	if bytes.HasPrefix(content, []byte{0xef, 0xbb, 0xbf}) {
+		bom, content = append([]byte(nil), content[:3]...), content[3:]
+	}
+
+	endOfLine := strings.ToLower(def.Raw["end_of_line"])
+	if endOfLine == "unset" {
+		endOfLine = ""
+	}
+	desiredEOL := ""
+	switch endOfLine {
+	case "lf":
+		desiredEOL = "\n"
+	case "cr":
+		desiredEOL = "\r"
+	case "crlf":
+		desiredEOL = "\r\n"
+	case "":
+	default:
+		// Unknown values are reported by validation; never guess a rewrite.
+		return false, nil
+	}
+
+	trim := def.Raw["trim_trailing_whitespace"] == "true" && !cfg.Disable.TrimTrailingWhitespace
+	insert := strings.ToLower(def.Raw["insert_final_newline"])
+	if insert == "unset" {
+		insert = ""
+	}
+	if insert != "" && insert != "true" && insert != "false" {
+		return false, nil
+	}
+	if cfg.Disable.EndOfLine {
+		desiredEOL = ""
+	}
+	if cfg.Disable.InsertFinalNewline {
+		insert = ""
+	}
+	if !trim && desiredEOL == "" && insert == "" {
+		return false, nil
+	}
+
+	parts := splitLines(content)
+	var out bytes.Buffer
+	for _, part := range parts {
+		line := part.text
+		if trim && !part.disabled {
+			line = bytes.TrimRight(line, " \t")
+		}
+		terminator := part.terminator
+		if desiredEOL != "" && len(terminator) != 0 {
+			terminator = []byte(desiredEOL)
+		}
+		out.Write(line)
+		out.Write(terminator)
+	}
+	fixed := out.Bytes()
+
+	if insert == "true" {
+		eol := desiredEOL
+		if eol == "" {
+			eol = detectFinalEOL(fixed)
+			if eol == "" {
+				eol = "\n"
+			}
+		}
+		if !bytes.HasSuffix(fixed, []byte(eol)) {
+			fixed = append(fixed, eol...)
+		}
+	} else if insert == "false" {
+		for len(fixed) > 0 {
+			if bytes.HasSuffix(fixed, []byte("\r\n")) {
+				fixed = fixed[:len(fixed)-2]
+			} else if fixed[len(fixed)-1] == '\r' || fixed[len(fixed)-1] == '\n' {
+				fixed = fixed[:len(fixed)-1]
+			} else {
+				break
+			}
+		}
+	}
+
+	fixed = append(bom, fixed...)
+	if bytes.Equal(original, fixed) {
+		return false, nil
+	}
+	if err := atomicWrite(filePath, fixed, fileMode(info), info); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func verbose(cfg *config.Config, format string, args ...any) {
+	if cfg.Logger != nil {
+		cfg.Logger.Verbose(format, args...)
+	}
+}
+
+// atomicWrite writes in the target directory and then renames the complete
+// file into place. This is crash-resistant and atomic on platforms/filesystems
+// where os.Rename provides those guarantees (Go documents that non-Unix
+// replacement is not atomic). It retains supported permission bits. The temp
+// file is always cleaned up on failure. Symlinks are rejected by FixFile before
+// this function is called. Replacing a path does not update other hard links.
+func atomicWrite(path string, content []byte, mode os.FileMode, original os.FileInfo) (err error) {
+	dir, base := splitPath(path)
+	tmp, err := os.CreateTemp(dir, "."+base+".editorconfig-checker-*")
+	if err != nil {
+		return fmt.Errorf("create temporary file for %s: %w", path, err)
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		if removeErr := os.Remove(tmpName); err == nil && removeErr != nil && !os.IsNotExist(removeErr) {
+			err = fmt.Errorf("remove temporary file %s: %w", tmpName, removeErr)
+		}
+	}()
+	if _, err = tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temporary file for %s: %w", path, err)
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary file for %s: %w", path, err)
+	}
+	// Set permissions after writing because Unix clears setuid/setgid bits
+	// when a file's contents are modified.
+	if err = tmp.Chmod(mode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("set permissions on temporary file for %s: %w", path, err)
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temporary file metadata for %s: %w", path, err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("close temporary file for %s: %w", path, err)
+	}
+	current, statErr := os.Lstat(path)
+	if statErr != nil {
+		return fmt.Errorf("check %s before replacement: %w", path, statErr)
+	}
+	if !current.Mode().IsRegular() || !os.SameFile(original, current) || current.Size() != original.Size() || !current.ModTime().Equal(original.ModTime()) {
+		return fmt.Errorf("refusing to replace %s: file changed while it was being fixed", path)
+	}
+	if err = os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}
+
+func fileMode(info os.FileInfo) os.FileMode {
+	return info.Mode() & (os.ModePerm | os.ModeSetuid | os.ModeSetgid | os.ModeSticky)
+}
+
+func splitPath(path string) (string, string) {
+	dir := filepath.Dir(path)
+	if dir == "" {
+		dir = "."
+	}
+	return dir, filepath.Base(path)
+}
+
+type linePart struct {
+	text, terminator []byte
+	disabled         bool
+}
+
+func splitLines(content []byte) []linePart {
+	var result []linePart
+	for len(content) > 0 {
+		idx := bytes.IndexAny(content, "\r\n")
+		if idx < 0 {
+			result = append(result, linePart{text: append([]byte(nil), content...)})
+			break
+		}
+		termLen := 1
+		if content[idx] == '\r' && idx+1 < len(content) && content[idx+1] == '\n' {
+			termLen = 2
+		}
+		result = append(result, linePart{text: append([]byte(nil), content[:idx]...), terminator: append([]byte(nil), content[idx:idx+termLen]...)})
+		content = content[idx+termLen:]
+	}
+	// Match the line-scoped directives understood by validation. Global rules
+	// (line endings and final newlines) are intentionally not line-scoped, but
+	// trailing whitespace is.
+	const (
+		disable              = "editorconfig-checker-disable"
+		disableLine          = "editorconfig-checker-disable-line"
+		disableNextDirective = "editorconfig-checker-disable-next-line"
+		enable               = "editorconfig-checker-enable"
+	)
+	disabled, disableNext := false, false
+	for i := range result {
+		line := string(result[i].text)
+		if disabled && strings.Contains(line, enable) {
+			disabled = false
+		}
+		result[i].disabled = disabled || disableNext
+		if disableNext {
+			disableNext = false
+		}
+		idx := strings.Index(line, disable)
+		if idx < 0 {
+			continue
+		}
+		directive := line[idx:]
+		if strings.Contains(directive, disableNextDirective) {
+			disableNext = true
+		}
+		if strings.Contains(directive, disableLine) {
+			result[i].disabled = true
+		}
+		if !strings.Contains(directive, disableNextDirective) && !strings.Contains(directive, disableLine) {
+			disabled = true
+			// A block-disable directive is itself skipped by validation.
+			result[i].disabled = true
+		}
+	}
+	return result
+}
+
+func detectFinalEOL(content []byte) string {
+	if bytes.HasSuffix(content, []byte("\r\n")) {
+		return "\r\n"
+	}
+	if bytes.HasSuffix(content, []byte("\r")) {
+		return "\r"
+	}
+	if bytes.HasSuffix(content, []byte("\n")) {
+		return "\n"
+	}
+	return ""
+}
+
+func hasDisableFile(content []byte) bool {
+	first := content
+	if idx := bytes.IndexAny(first, "\r\n"); idx >= 0 {
+		first = first[:idx]
+	}
+	return bytes.Contains(first, []byte("editorconfig-checker-disable-file"))
+}

--- a/pkg/fix/fix_test.go
+++ b/pkg/fix/fix_test.go
@@ -1,0 +1,243 @@
+package fix
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/editorconfig-checker/editorconfig-checker/v3/pkg/config"
+	editorconfig "github.com/editorconfig/editorconfig-core-go/v2"
+)
+
+func definition(raw map[string]string) *editorconfig.Definition {
+	return &editorconfig.Definition{Raw: raw}
+}
+
+func TestFixFile(t *testing.T) {
+	tests := []struct {
+		name, input, want string
+		rules             map[string]string
+	}{
+		{"lf", "a\r\nb\r", "a\nb\n", map[string]string{"end_of_line": "lf", "insert_final_newline": "true"}},
+		{"crlf", "a\nb\r", "a\r\nb\r\n", map[string]string{"end_of_line": "crlf", "insert_final_newline": "true"}},
+		{"cr", "a\nb\r\n", "a\rb\r", map[string]string{"end_of_line": "cr", "insert_final_newline": "true"}},
+		{"mixed", "a\r\nb\nc\r", "a\nb\nc", map[string]string{"end_of_line": "lf", "insert_final_newline": "false"}},
+		{"trailing", "a \n b\t", "a\n b", map[string]string{"trim_trailing_whitespace": "true", "insert_final_newline": "false"}},
+		{"empty-final-newline", "", "", map[string]string{"insert_final_newline": "true"}},
+		{"no-final-newline", "a\n\n", "a", map[string]string{"insert_final_newline": "false"}},
+		{"false-policy", "a\n", "a", map[string]string{"insert_final_newline": "false"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			if err := os.WriteFile(path, []byte(tt.input), 0755); err != nil {
+				t.Fatal(err)
+			}
+			cfg := *config.NewConfig(nil)
+			changed, err := FixFile(path, cfg, definition(tt.rules))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+			if !changed && tt.name == "empty-final-newline" {
+				return
+			}
+			if !changed {
+				t.Fatal("expected file to change")
+			}
+			changed, err = FixFile(path, cfg, definition(tt.rules))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				t.Fatal("fix is not idempotent")
+			}
+			mode, _ := os.Stat(path)
+			if mode.Mode().Perm() != 0755 {
+				t.Fatalf("permissions changed: %o", mode.Mode().Perm())
+			}
+		})
+	}
+}
+
+func TestFixFileRespectsDisable(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+	input := "// editorconfig-checker-disable-next-line\na \n"
+	if err := os.WriteFile(path, []byte(input), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := *config.NewConfig(nil)
+	changed, err := FixFile(path, cfg, definition(map[string]string{"trim_trailing_whitespace": "true"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("disabled line should not be changed")
+	}
+}
+
+func TestFixFileDirectiveScopes(t *testing.T) {
+	tests := []struct {
+		name, input, want string
+	}{
+		{"disable-file", "// editorconfig-checker-disable-file \na \n", "// editorconfig-checker-disable-file \na \n"},
+		{"disable-block", "// editorconfig-checker-disable  \na \n// editorconfig-checker-enable  \nb \n", "// editorconfig-checker-disable  \na \n// editorconfig-checker-enable\nb\n"},
+		{"disable-line", "a  // editorconfig-checker-disable-line  \nb  \n", "a  // editorconfig-checker-disable-line  \nb\n"},
+		{"disable-next-line", "// editorconfig-checker-disable-next-line  \na  \nb  \n", "// editorconfig-checker-disable-next-line\na  \nb\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			if err := os.WriteFile(path, []byte(tt.input), 0644); err != nil {
+				t.Fatal(err)
+			}
+			cfg := *config.NewConfig(nil)
+			changed, err := FixFile(path, cfg, definition(map[string]string{"trim_trailing_whitespace": "true"}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, _ := os.ReadFile(path)
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+			if changed == (tt.name == "disable-file") {
+				t.Fatalf("changed=%v for %s", changed, tt.name)
+			}
+		})
+	}
+}
+
+func TestFixFileSkipsUnsafeFilesAndSymlinks(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"non-utf8", []byte{0xff, 'a', ' ', '\n'}},
+		{"binary", []byte{'a', 0, ' ', '\n'}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			if err := os.WriteFile(path, tt.data, 0644); err != nil {
+				t.Fatal(err)
+			}
+			cfg := *config.NewConfig(nil)
+			changed, err := FixFile(path, cfg, definition(map[string]string{"trim_trailing_whitespace": "true"}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				t.Fatal("unsafe file was changed")
+			}
+		})
+	}
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.WriteFile(target, []byte("a \n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	cfg := *config.NewConfig(nil)
+	changed, err := FixFile(link, cfg, definition(map[string]string{"trim_trailing_whitespace": "true"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("symlink was changed")
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "a \n" {
+		t.Fatalf("symlink target changed: %q", got)
+	}
+}
+
+func TestFixFilePreservesBOMAndHonorsDisabledChecks(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+	input := append([]byte{0xef, 0xbb, 0xbf}, []byte("a \r\nb")...)
+	if err := os.WriteFile(path, input, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := *config.NewConfig(nil)
+	cfg.Disable.TrimTrailingWhitespace = true
+	cfg.Disable.EndOfLine = true
+	cfg.Disable.InsertFinalNewline = true
+	changed, err := FixFile(path, cfg, definition(map[string]string{"trim_trailing_whitespace": "true", "end_of_line": "lf", "insert_final_newline": "true"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatal("disabled checks changed file")
+	}
+	cfg.Disable = config.DisabledChecks{}
+	changed, err = FixFile(path, cfg, definition(map[string]string{"trim_trailing_whitespace": "true", "end_of_line": "lf", "insert_final_newline": "true"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("enabled checks did not change file")
+	}
+	got, _ := os.ReadFile(path)
+	want := append([]byte{0xef, 0xbb, 0xbf}, []byte("a\nb\n")...)
+	if string(got) != string(want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFixFileDisableEndOfLineStillAddsNewline(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(path, []byte("a"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := *config.NewConfig(nil)
+	cfg.Disable.EndOfLine = true
+	changed, err := FixFile(path, cfg, definition(map[string]string{"end_of_line": "crlf", "insert_final_newline": "true"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("final newline was not fixed")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "a\n" {
+		t.Fatalf("got %q, want LF without configured EOL enforcement", got)
+	}
+}
+
+func TestFixFilePreservesSpecialPermissionBits(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix special permission bits")
+	}
+	path := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(path, []byte("a "), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0755|os.ModeSetuid); err != nil {
+		t.Fatal(err)
+	}
+	cfg := *config.NewConfig(nil)
+	changed, err := FixFile(path, cfg, definition(map[string]string{"trim_trailing_whitespace": "true"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !changed {
+		t.Fatal("file was not fixed")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 || info.Mode()&os.ModeSetuid == 0 {
+		t.Fatalf("permission bits changed: got %v", info.Mode())
+	}
+}

--- a/pkg/fix/fix_test.go
+++ b/pkg/fix/fix_test.go
@@ -83,6 +83,159 @@ func TestFixFileRespectsDisable(t *testing.T) {
 	}
 }
 
+func TestFixFileSkipsEmptyAndNonRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	cfg := *config.NewConfig(nil)
+	if changed, err := FixFile(dir, cfg, definition(map[string]string{"insert_final_newline": "true"})); err != nil || changed {
+		t.Fatalf("directory: changed=%v, err=%v", changed, err)
+	}
+
+	empty := filepath.Join(dir, "empty.txt")
+	if err := os.WriteFile(empty, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := FixFile(empty, cfg, definition(map[string]string{"insert_final_newline": "true"})); err != nil || changed {
+		t.Fatalf("empty file: changed=%v, err=%v", changed, err)
+	}
+
+	if _, err := FixFile(filepath.Join(dir, "missing.txt"), cfg, definition(nil)); err == nil {
+		t.Fatal("missing file should return an error")
+	}
+}
+
+func TestFixFileSkipsInvalidRules(t *testing.T) {
+	tests := []struct {
+		name  string
+		rules map[string]string
+	}{
+		{"invalid-eol", map[string]string{"end_of_line": "dos"}},
+		{"invalid-final-newline", map[string]string{"insert_final_newline": "sometimes"}},
+		{"unset-rules", map[string]string{"end_of_line": "unset", "insert_final_newline": "unset"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			input := []byte("value\r\n")
+			if err := os.WriteFile(path, input, 0644); err != nil {
+				t.Fatal(err)
+			}
+			cfg := *config.NewConfig(nil)
+			changed, err := FixFile(path, cfg, definition(tt.rules))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				t.Fatal("invalid or unset rules should not change the file")
+			}
+			got, _ := os.ReadFile(path)
+			if string(got) != string(input) {
+				t.Fatalf("got %q, want %q", got, input)
+			}
+		})
+	}
+}
+
+func TestFixFileSupportsConfiguredPolicies(t *testing.T) {
+	tests := []struct {
+		name, input, want, eol string
+	}{
+		{"lf", "a\r\nb", "a\nb\n", "\n"},
+		{"crlf", "a\nb", "a\r\nb\r\n", "\r\n"},
+		{"cr", "a\n b\r\n", "a\r b\r", "\r"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			if err := os.WriteFile(path, []byte(tt.input), 0644); err != nil {
+				t.Fatal(err)
+			}
+			cfg := *config.NewConfig(nil)
+			changed, err := FixFile(path, cfg, definition(map[string]string{
+				"end_of_line":          tt.name,
+				"insert_final_newline": "true",
+			}))
+			if err != nil || !changed {
+				t.Fatalf("changed=%v, err=%v", changed, err)
+			}
+			got, _ := os.ReadFile(path)
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFixHelpers(t *testing.T) {
+	for _, test := range []struct {
+		raw, want string
+	}{
+		{"", ""}, {"unset", ""}, {"lf", "\n"}, {"cr", "\r"}, {"crlf", "\r\n"},
+	} {
+		got, ok := configuredEOL(test.raw)
+		if !ok || got != test.want {
+			t.Errorf("configuredEOL(%q) = %q, %v", test.raw, got, ok)
+		}
+	}
+	if _, ok := configuredEOL("invalid"); ok {
+		t.Fatal("invalid EOL should be rejected")
+	}
+	for _, test := range []string{"", "unset", "true", "false"} {
+		if _, ok := configuredFinalNewline(test); !ok {
+			t.Errorf("configuredFinalNewline(%q) rejected", test)
+		}
+	}
+	if _, ok := configuredFinalNewline("invalid"); ok {
+		t.Fatal("invalid final-newline value should be rejected")
+	}
+	if !isSupportedEncoding("UTF-8-SIG") || !isSupportedEncoding("ascii") || !isSupportedEncoding("unknown") {
+		t.Fatal("expected supported encodings")
+	}
+	if isSupportedEncoding("latin1") {
+		t.Fatal("latin1 should remain check-only")
+	}
+
+	for _, test := range []struct {
+		input, want, policy string
+	}{
+		{"a", "a\n", "true"},
+		{"a\r\n", "a", "false"},
+		{"a\r", "a\r", "true"},
+	} {
+		got := fixFinalNewline([]byte(test.input), test.policy, "")
+		if string(got) != test.want {
+			t.Errorf("fixFinalNewline(%q, %q) = %q, want %q", test.input, test.policy, got, test.want)
+		}
+	}
+}
+
+func TestAtomicWriteRefusesLostUpdate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(path, []byte("before"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("changed concurrently"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := atomicWrite(path, []byte("replacement"), fileMode(info), info); err == nil {
+		t.Fatal("expected replacement to be rejected after a concurrent change")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "changed concurrently" {
+		t.Fatalf("lost update changed file to %q", got)
+	}
+}
+
+func TestSplitPathForFilesInCurrentDirectory(t *testing.T) {
+	dir, base := splitPath("file.txt")
+	if dir != "." || base != "file.txt" {
+		t.Fatalf("splitPath returned %q, %q", dir, base)
+	}
+}
+
 func TestFixFileDirectiveScopes(t *testing.T) {
 	tests := []struct {
 		name, input, want string

--- a/pkg/fix/fix_test.go
+++ b/pkg/fix/fix_test.go
@@ -1,6 +1,7 @@
 package fix
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -101,6 +102,14 @@ func TestFixFileSkipsEmptyAndNonRegularFiles(t *testing.T) {
 	if _, err := FixFile(filepath.Join(dir, "missing.txt"), cfg, definition(nil)); err == nil {
 		t.Fatal("missing file should return an error")
 	}
+
+	noOp := filepath.Join(dir, "no-op.txt")
+	if err := os.WriteFile(noOp, []byte("already clean\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if changed, err := FixFile(noOp, cfg, definition(nil)); err != nil || changed {
+		t.Fatalf("no-op policy: changed=%v, err=%v", changed, err)
+	}
 }
 
 func TestFixFileSkipsInvalidRules(t *testing.T) {
@@ -129,6 +138,33 @@ func TestFixFileSkipsInvalidRules(t *testing.T) {
 			}
 			got, _ := os.ReadFile(path)
 			if string(got) != string(input) {
+				t.Fatalf("got %q, want %q", got, input)
+			}
+		})
+	}
+}
+
+func TestFixFilePreservesExistingNewlinesWhenEOLDisabled(t *testing.T) {
+	for _, input := range []string{"value\n", "value\r\n"} {
+		t.Run(fmt.Sprintf("%x", input), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			if err := os.WriteFile(path, []byte(input), 0644); err != nil {
+				t.Fatal(err)
+			}
+			cfg := *config.NewConfig(nil)
+			cfg.Disable.EndOfLine = true
+			changed, err := FixFile(path, cfg, definition(map[string]string{
+				"end_of_line":          "crlf",
+				"insert_final_newline": "true",
+			}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if changed {
+				t.Fatal("already-present final newline should be preserved")
+			}
+			got, _ := os.ReadFile(path)
+			if string(got) != input {
 				t.Fatalf("got %q, want %q", got, input)
 			}
 		})
@@ -206,6 +242,18 @@ func TestFixHelpers(t *testing.T) {
 			t.Errorf("fixFinalNewline(%q, %q) = %q, want %q", test.input, test.policy, got, test.want)
 		}
 	}
+	for _, test := range []struct {
+		input, want string
+	}{
+		{"value\r\n", "\r\n"},
+		{"value\n", "\n"},
+		{"value\r", "\r"},
+		{"value", ""},
+	} {
+		if got := detectFinalEOL([]byte(test.input)); got != test.want {
+			t.Errorf("detectFinalEOL(%q) = %q, want %q", test.input, got, test.want)
+		}
+	}
 }
 
 func TestAtomicWriteRefusesLostUpdate(t *testing.T) {
@@ -229,10 +277,13 @@ func TestAtomicWriteRefusesLostUpdate(t *testing.T) {
 	}
 }
 
-func TestSplitPathForFilesInCurrentDirectory(t *testing.T) {
-	dir, base := splitPath("file.txt")
-	if dir != "." || base != "file.txt" {
-		t.Fatalf("splitPath returned %q, %q", dir, base)
+func TestAtomicWriteFailureBeforeReplacement(t *testing.T) {
+	dir := t.TempDir()
+	if err := atomicWrite(filepath.Join(dir, "missing.txt"), []byte("replacement"), 0644, nil); err == nil {
+		t.Fatal("expected missing target to be rejected")
+	}
+	if err := atomicWrite(filepath.Join(dir, "missing-parent", "file.txt"), []byte("replacement"), 0644, nil); err == nil {
+		t.Fatal("expected temporary-file creation to fail for a missing parent")
 	}
 }
 
@@ -273,6 +324,7 @@ func TestFixFileSkipsUnsafeFilesAndSymlinks(t *testing.T) {
 		data []byte
 	}{
 		{"non-utf8", []byte{0xff, 'a', ' ', '\n'}},
+		{"invalid-utf8", []byte{0x81, 'a', ' ', '\n'}},
 		{"binary", []byte{'a', 0, ' ', '\n'}},
 	}
 	for _, tt := range tests {

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -189,10 +189,16 @@ func ValidateFileWithDefinition(filePath string, config config.Config, def *edit
 
 // ValidateFinalNewline runs the final newline validator and processes the error into the proper type
 func ValidateFinalNewline(fileInformation files.FileInformation, config config.Config) error.ValidationError {
+	endOfLine := fileInformation.Editorconfig.Raw["end_of_line"]
+	if config.Disable.EndOfLine {
+		// A disabled end-of-line check must not make the final-newline check
+		// enforce the configured line-ending representation as a side effect.
+		endOfLine = ""
+	}
 	if currentError := validators.FinalNewline(
 		fileInformation.Content,
 		fileInformation.Editorconfig.Raw["insert_final_newline"],
-		fileInformation.Editorconfig.Raw["end_of_line"]); !config.Disable.InsertFinalNewline && currentError != nil {
+		endOfLine); !config.Disable.InsertFinalNewline && currentError != nil {
 		config.Logger.Verbose("Final newline error found in %s", fileInformation.FilePath)
 		return error.ValidationError{LineNumber: -1, Message: currentError}
 	}


### PR DESCRIPTION
## Summary

Add an opt-in `--fix` mode that applies a deliberately small set of safe EditorConfig fixes before validation.

This starts a fresh implementation based on the supportive discussion in [issue #14](https://github.com/editorconfig-checker/editorconfig-checker/issues/14), rather than reviving the older [pull request #61](https://github.com/editorconfig-checker/editorconfig-checker/pull/61). The fresh implementation narrows the scope and documents the safety boundary explicitly.

## Supported fixes

`--fix` currently applies only:

- `trim_trailing_whitespace = true` (while honoring line-level disable directives)
- `end_of_line = lf`, `cr`, or `crlf`
- `insert_final_newline = true` or `false`

Indentation, `indent_size`, `max_line_length`, and `charset` remain check-only. Unknown rule values are reported by normal validation and are never guessed during fixing.

## Safety and file semantics

- Files are checked before modification and only regular, non-empty, non-symlink files are eligible.
- Binary-like content, invalid UTF-8, and unsupported encodings are skipped rather than rewritten.
- UTF-8 BOMs are preserved.
- File permissions, including Unix special permission bits, are retained.
- File-level disable directives and applicable line-level disable directives are honored.
- Content is written through a same-directory temporary file and replacement. This is crash-resistant and atomic where the operating system/filesystem provides those guarantees; hard links to the old inode are not updated.
- A second `--fix` run is idempotent.

The original file is revalidated immediately before replacement. If the path, inode, size, or modification time changed while fixing, replacement is refused rather than overwriting concurrent edits. Fix errors return the existing error exit status; after successful fixes, the normal validation pipeline still runs and determines the final exit status.

## Validation

- `make test`
- `go test -race ./...`
- `make build`
- `GOOS=windows GOARCH=amd64 go build -o /tmp/editorconfig-checker-windows-amd64.exe ./cmd/editorconfig-checker`
- `git diff --check`
