### PR TITLE
fix: allow builds with Go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v7
         with:
-          go-version-file: "go.mod"
+          go-version: stable
       - run: make build
       - run: make test
       - run: make run
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version-file: "go.mod"
+          go-version: stable
       - run: make test
       - run: make run
       - run: make bench
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version-file: "go.mod"
+          go-version: stable
       - run: make test
       - run: make run
       - run: make bench

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v7
         with:
-          go-version-file: "go.mod"
+          go-version: stable
           cache: true
 
       - name: Set up QEMU

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/editorconfig-checker/editorconfig-checker/v3 // x-release-please-major
 
-go 1.27.0
+go 1.26.0
 
 require (
 	github.com/editorconfig/editorconfig-core-go/v2 v2.6.4


### PR DESCRIPTION
#614 bumped the the `go` version in `go.mod` from `go 1.25.0` to `go 1.27.0`. This specifies that the minimum version of Go required to build `editorconfig-checker` is now 1.27 ([ref](https://go.dev/ref/mod#go-mod-file-go)). However, this is not correct: `editorconfig-checker` builds just fine with Go 1.26.

The downside of the `go 1.27.0` directive is the everything that depends on `editorconfig-checker` now must be built with minimum Go 1.27 as well, effectively breaking `editorconfig-checker` for any project that uses it via a `tool` directive and wanting to support an older version of Go.

This PR changes the minimum version of Go to 1.26.0, which is a reasonable default since Go 1.26.x is the oldest version of Go supported by the Go team.