### PR TITLE
ci!: migrate to goreleaser dockers_v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,153 +64,28 @@ nfpms:
       - termux.deb
       - archlinux
 
-dockers:
+dockers_v2:
   - id: docker-linux-amd64
     ids:
       - editorconfig-checker
-    goos: linux
-    goarch: amd64
-    use: buildx
     dockerfile: Dockerfile
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.description=A tool to verify that your files are in harmony with your .editorconfig"
-      - "--label=org.opencontainers.image.licenses={{ .Env.REPO_LICENSE }}"
-      - "--platform=linux/amd64"
-  - id: docker-linux-i386
-    ids:
-      - editorconfig-checker
-    goos: linux
-    goarch: '386'
-    use: buildx
-    dockerfile: Dockerfile
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.description=A tool to verify that your files are in harmony with your .editorconfig"
-      - "--label=org.opencontainers.image.licenses={{ .Env.REPO_LICENSE }}"
-      - "--platform=linux/386"
-  - id: docker-linux-arm64
-    ids:
-      - editorconfig-checker
-    goos: linux
-    goarch: arm64
-    skip_push: false
-    use: buildx
-    dockerfile: Dockerfile
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.description=A tool to verify that your files are in harmony with your .editorconfig"
-      - "--label=org.opencontainers.image.licenses={{ .Env.REPO_LICENSE }}"
-      - "--platform=linux/arm64/v8"
-  - id: docker-linux-arm32v6
-    ids:
-      - editorconfig-checker
-    goos: linux
-    goarch: arm
-    goarm: 6
-    skip_push: false
-    use: buildx
-    dockerfile: Dockerfile
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-    build_flag_templates:
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--label=org.opencontainers.image.description=A tool to verify that your files are in harmony with your .editorconfig"
-      - "--label=org.opencontainers.image.licenses={{ .Env.REPO_LICENSE }}"
-      - "--platform=linux/arm/v6"
-docker_manifests:
-  - id: docker_manifest-dockerhub-tag
-    skip_push: false
-    name_template: "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}"
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-  - id: docker_manifest-ghcr-tag
-    skip_push: false
-    name_template: "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
+    images:
+      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker"
+      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker"
+    tags:
+      - latest
+      - "{{ .Version }}"
+      - "{{ .Major }}"
+      - "{{ .Major }}.{{ .Minor }}"
+    labels:
+      org.opencontainers.image.created: "{{.Date}}"
+      org.opencontainers.image.title: "{{.ProjectName}}"
+      org.opencontainers.image.revision: "{{.FullCommit}}"
+      org.opencontainers.image.version: "{{.Version}}"
+      org.opencontainers.image.source: "{{.GitURL}}"
+      org.opencontainers.image.description: A tool to verify that your files are in harmony with your .editorconfig"
+      org.opencontainers.image.licenses: "{{ .Env.REPO_LICENSE }}"
 
-  - id: docker_manifest-dockerhub-major
-    skip_push: auto
-    name_template: "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Major }}"
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-  - id: docker_manifest-dockerhub-major-minor
-    skip_push: auto
-    name_template: "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-  - id: docker_manifest-dockerhub-latest
-    skip_push: auto
-    name_template: "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:latest"
-    image_templates:
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "{{ .Env.DOCKERHUB_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-
-  - id: docker_manifest-ghcr-major
-    skip_push: auto
-    name_template: "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Major }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-  - id: docker_manifest-ghcr-major-minor
-    skip_push: auto
-    name_template: "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Major }}.{{ .Minor }}"
-    image_templates:
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
-  - id: docker_manifest-ghcr-latest
-    skip_push: auto
-    name_template: "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:latest"
-    image_templates:
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-amd64"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm64v8"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-arm32v6"
-      - "ghcr.io/{{ .Env.GHCR_USERNAME }}/editorconfig-checker:{{ .Version }}-i386"
 checksum:
   name_template: "checksums.txt"
 sboms:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@
 
 FROM alpine:latest
 
+ARG TARGETPLATFORM
+
 RUN apk add --no-cache git \
     && git config --global --add safe.directory /check
 WORKDIR /check/
 
-COPY editorconfig-checker /usr/bin/
+COPY $TARGETPLATFORM/editorconfig-checker /usr/bin/
 
 CMD ["/usr/bin/editorconfig-checker"]


### PR DESCRIPTION
Due to the way dockers_v2 works, this will mean we no longer publish single-arch tags:

- `3.11.2-amd64`
- `3.11.2-arm32v6`
- `3.11.2-arm64v8`
- `3.11.2-i386`

So the only tags being released in the future will be

- `3.11.2`
- `3.11`
- `3`
- `latest`

However, looking at the only statistics available to us (the per-image pulls in github) the single-arch images were used only 4 times, which exactly matches the number of multi-arch tags we are creating.

<!--
BEGIN_COMMIT_OVERRIDE
ci!: migrate to goreleaser dockers_v2. (#617)<br>This means we stop publishing the arch-suffixed images like `3.11.2-amd64` or `3.11.2-arm64v8`. All these architectures are still provided in the multiarch tag `3.11.2`.
END_COMMIT_OVERRIDE
-->