### PR TITLE
docs: document our decision to support oldstable go

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,3 +682,7 @@ However, as it is a code quality tool, it's not always clear when a minor or maj
   - Removal of a [path to exclude by default](#default-excludes).
   - Removal of support for an [editorconfig](https://editorconfig.org/) property.
   - Bug fixes, which result in **editorconfig-checker** reporting more linting errors, because the previous behavior was incorrect according to the [editorconfig specification](https://editorconfig.org/).
+
+## Supported versions of Go
+
+We officially support the last two releases of Go. Our published binaries will always be built using the latest available patch version of Go, and our [go.mod](go.mod) will always stays at the minor version before that. We encourage everyone to build editorconfig-checker with the highest version practical, but recognize that some users cannot upgrade to a new version of go immediately.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,9 @@ module github.com/editorconfig-checker/editorconfig-checker/v3 // x-release-plea
 // this version is always kept at the original release of the oldstable go version.
 go 1.26.0
 
+// but suggest a current toolchain
+toolchain go1.27.0
+
 require (
 	github.com/editorconfig/editorconfig-core-go/v2 v2.6.4
 	github.com/gabriel-vasile/mimetype v1.4.15

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/editorconfig-checker/editorconfig-checker/v3 // x-release-please-major
 
+// this version is always kept at the original release of the oldstable go version.
 go 1.26.0
 
 require (


### PR DESCRIPTION
This is a documentation and one tiny addition to hopefully steer users of `go install` to use the right toolchain to build (the toolchain directive only is effective, if the module is being build as the main module).

But I'd request @twpayne to verify that this works as I understood it.