### PR TITLE
fix: keep the file's existing line ending when adding a final newline

### DIFF
--- a/internal/fix/fix.go
+++ b/internal/fix/fix.go
@@ -311,17 +311,24 @@ func splitLines(content []byte) []linePart {
 	return result
 }
 
+// detectFinalEOL returns the line terminator that ends the last complete line
+// of content, or "" when content holds no line terminator at all. It looks for
+// the last terminator anywhere in content rather than only at the suffix,
+// because the caller needs an answer precisely when content does *not* end
+// with a terminator; a suffix-only check returns "" in exactly that case and
+// leaves the caller guessing.
 func detectFinalEOL(content []byte) string {
-	if bytes.HasSuffix(content, []byte("\r\n")) {
-		return "\r\n"
+	idx := bytes.LastIndexAny(content, "\r\n")
+	if idx < 0 {
+		return ""
 	}
-	if bytes.HasSuffix(content, []byte("\r")) {
+	if content[idx] == '\r' {
 		return "\r"
 	}
-	if bytes.HasSuffix(content, []byte("\n")) {
-		return "\n"
+	if idx > 0 && content[idx-1] == '\r' {
+		return "\r\n"
 	}
-	return ""
+	return "\n"
 }
 
 func hasDisableFile(content []byte) bool {

--- a/internal/fix/fix_test.go
+++ b/internal/fix/fix_test.go
@@ -210,6 +210,37 @@ func TestFixFileSupportsConfiguredPolicies(t *testing.T) {
 	}
 }
 
+// With end_of_line unset the fixer must not impose a line ending: adding the
+// final newline has to reuse the one the file already uses, or a CRLF file
+// silently becomes mixed.
+func TestFixFileKeepsExistingEOLWhenEndOfLineUnset(t *testing.T) {
+	for _, tt := range []struct {
+		name, input, want string
+	}{
+		{"crlf", "alpha\r\nbeta\r\ngamma", "alpha\r\nbeta\r\ngamma\r\n"},
+		{"cr", "alpha\rbeta\rgamma", "alpha\rbeta\rgamma\r"},
+		{"lf", "alpha\nbeta\ngamma", "alpha\nbeta\ngamma\n"},
+		{"single line has no terminator to reuse", "alpha", "alpha\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "file.txt")
+			if err := os.WriteFile(path, []byte(tt.input), 0644); err != nil {
+				t.Fatal(err)
+			}
+			changed, err := File(path, *config.NewConfig(nil), definition(map[string]string{
+				"insert_final_newline": "true",
+			}))
+			if err != nil || !changed {
+				t.Fatalf("changed=%v, err=%v", changed, err)
+			}
+			got, _ := os.ReadFile(path)
+			if string(got) != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFixHelpers(t *testing.T) {
 	for _, test := range []struct {
 		raw, want string
@@ -245,6 +276,11 @@ func TestFixHelpers(t *testing.T) {
 		{"a", "a\n", "true"},
 		{"a\r\n", "a", "false"},
 		{"a\r", "a\r", "true"},
+		// A file missing only its final newline keeps the line ending its
+		// other lines already use, instead of always gaining an LF.
+		{"a\r\nb", "a\r\nb\r\n", "true"},
+		{"a\rb", "a\rb\r", "true"},
+		{"a\nb", "a\nb\n", "true"},
 	} {
 		got := fixFinalNewline([]byte(test.input), test.policy, "")
 		if string(got) != test.want {
@@ -258,6 +294,11 @@ func TestFixHelpers(t *testing.T) {
 		{"value\n", "\n"},
 		{"value\r", "\r"},
 		{"value", ""},
+		// Content that does not end with a terminator still reports the one
+		// its earlier lines use.
+		{"a\r\nb", "\r\n"},
+		{"a\rb", "\r"},
+		{"a\nb", "\n"},
 	} {
 		if got := detectFinalEOL([]byte(test.input)); got != test.want {
 			t.Errorf("detectFinalEOL(%q) = %q, want %q", test.input, got, test.want)


### PR DESCRIPTION
With `end_of_line` unset, `--fix` appends an **LF** final newline to a
consistently-CRLF file, leaving it mixed. The checker can't catch it: with
`end_of_line` unset it deliberately accepts any ending (#580, #594).

```
.editorconfig: [*] insert_final_newline = true
before:  "alpha\r\nbeta\r\ngamma"
--fix →  "alpha\r\nbeta\r\ngamma\n"    # mixed
now      "alpha\r\nbeta\r\ngamma\r\n"
```

`detectFinalEOL` only inspects the suffix, so it returns `""` in exactly the
state its caller asks about — a file with no final newline — and the caller
falls back to `"\n"`. Its non-empty return can never change the outcome: it is
non-empty only when the content already ends with that ending, and `HasSuffix`
then skips the append. So the appended ending was always LF. It now reads the
last terminator anywhere in the file.

The tests were blind: every `detectFinalEOL` row already ended with a newline.

Naive alternative (first ending found anywhere) **passes the whole suite**, so
the tests don't decide it. Over 21,844 enumerated inputs the two agree on all
6,745 with a consistent or absent ending, differing only on already-mixed
files. I took the last complete line's ending, the line the new one continues.

Ran `go test -race ./...`, `make test`, golangci-lint 2.13.1 and the binary on
this repo — all clean. Reverting the helper fails only the new assertions.

AI-assisted (Claude Code, claude-opus-5); reviewed and verified by me.
